### PR TITLE
github migration, python2, bumpversion

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,23 @@
+[bumpversion]
+current_version = 1.10.2
+commit = True
+tag = True
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\.(?P<devnum>\d+))?
+serialize = 
+	{major}.{minor}.{patch}-{stage}.{devnum}
+	{major}.{minor}.{patch}
+
+[bumpversion:part:stage]
+optional_value = stable
+first_value = stable
+values = 
+	alpha
+	beta
+	stable
+
+[bumpversion:part:devnum]
+
+[bumpversion:file:setup.py]
+search = version='{current_version}',
+replace = version='{new_version}',
+

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@
 Python wrapper around running `geth` as a subprocess
 
 
-# Dependency
+## System Dependency
 
 This library requires the `geth` executable to be present.
 
 
-# Quickstart
+## Installation
 
 Installation
 
@@ -31,6 +31,9 @@ pip install py-geth[gevent]
 
 And then enable gevent based threads by setting the environment variable
 `GETH_THREADING_BACKEND=gevent`.
+
+
+## Quickstart
 
 
 To run geth connected to the mainnet
@@ -201,3 +204,63 @@ $ geth makedag 0 ~/.ethash
 
 This is especially important in CI environments like Travis-CI where your
 process will likely timeout during generation.
+
+
+## Development
+
+Clone the repository and then run:
+
+```sh
+pip install -e . -r requirements-dev.txt
+```
+
+
+### Running the tests
+
+You can run the tests with:
+
+```sh
+py.test tests
+```
+
+Or you can install `tox` to run the full test suite.
+
+
+### Releasing
+
+Pandoc is required for transforming the markdown README to the proper format to
+render correctly on pypi.
+
+For Debian-like systems:
+
+```
+apt install pandoc
+```
+
+Or on OSX:
+
+```sh
+brew install pandoc
+```
+
+To release a new version:
+
+```sh
+bumpversion $$VERSION_PART_TO_BUMP$$
+git push && git push --tags
+make release
+```
+
+
+#### How to bumpversion
+
+The version format for this repo is `{major}.{minor}.{patch}` for stable, and
+`{major}.{minor}.{patch}-{stage}.{devnum}` for unstable (`stage` can be alpha or beta).
+
+To issue the next version in line, use bumpversion and specify which part to bump,
+like `bumpversion minor` or `bumpversion devnum`.
+
+If you are in a beta version, `bumpversion stage` will switch to a stable.
+
+To issue an unstable version when the current version is stable, specify the
+new version explicitly, like `bumpversion --new-version 4.0.0-alpha.1 devnum`

--- a/geth/__init__.py
+++ b/geth/__init__.py
@@ -1,8 +1,6 @@
 import pkg_resources
-
-
-__version__ = pkg_resources.get_distribution("py-geth").version
-
+import sys
+import warnings
 
 from .main import (  # noqa: F401
     get_geth_version,
@@ -21,3 +19,14 @@ from .mixins import (  # noqa: F401
     InterceptedStreamsMixin,
     LoggingMixin,
 )
+
+
+if sys.version_info.major < 3:
+    warnings.simplefilter('always', DeprecationWarning)
+    warnings.warn(DeprecationWarning(
+        "The `py-geth` library is dropping support for Python 2.  Upgrade to Python 3."
+    ))
+    warnings.resetwarnings()
+
+
+__version__ = pkg_resources.get_distribution("py-geth").version

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,20 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import os
-
 from setuptools import (
     setup,
     find_packages,
 )
 
 
-DIR = os.path.dirname(os.path.abspath(__file__))
-
-readme = open(os.path.join(DIR, 'README.md')).read()
-
-
 setup(
     name='py-geth',
+    # *IMPORTANT*: Don't manually change the version here. Use the 'bumpversion' utility.
     version="1.10.2",
     description="""Run Go-Ethereum as a subprocess""",
-    long_description=readme,
+    long_description_markdown_filename='README.md',
     author='Piper Merriam',
     author_email='pipermerriam@gmail.com',
-    url='https://github.com/pipermerriam/py-geth',
+    url='https://github.com/ethereum/py-geth',
     include_package_data=True,
     py_modules=['geth'],
     install_requires=[


### PR DESCRIPTION
### What was wrong?

* github repository move to ethereum github account
* bumpversion for release building
* python2 deprecation

#### Cute Animal Picture

> put a cute animal picture here.
