### PR TITLE
is_dag_ready changed to is_dag_generated

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ True
 >>> geth.is_ipc_ready
 True
 >>> geth.wait_for_ipc(timeout=30)  # wait up to 30 seconds for the IPC socket to open
->>> geth.is_dag_ready
+>>> geth.is_dag_generated
 True
 >>> geth.is_mining
 True


### PR DESCRIPTION
is_dag_ready property is changed to is_dag_generated

### What was wrong?
in README "is_dag_ready" was there, however it has been renamed to is_dag_generated

### How was it fixed?
I fixed the README

#### Cute Animal Picture

> ![cute-baby-animals-32](https://user-images.githubusercontent.com/6905938/34316987-fec6dda8-e7c9-11e7-9f37-73b8d3ed39c6.jpg)

