### PR TITLE
Remove python2 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,13 +100,6 @@ common_go_v_1_10: &common_go_v_1_10
         key: cache-v5-{{ arch }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
 
 jobs:
-  py27-install-geth-v1.7.0:
-    <<: *common_go_v_1_7
-    docker:
-      - image: circleci/python:2.7
-        environment:
-          GETH_VERSION: v1.7.0
-          TOXENV: py27-install-geth-v1.7.0
   py34-install-geth-v1.7.0:
     <<: *common_go_v_1_7
     docker:
@@ -122,13 +115,6 @@ jobs:
           GETH_VERSION: v1.7.0
           TOXENV: py35-install-geth-v1.7.0
 
-  py27-install-geth-v1.7.2:
-    <<: *common_go_v_1_7
-    docker:
-      - image: circleci/python:2.7
-        environment:
-          GETH_VERSION: v1.7.2
-          TOXENV: py27-install-geth-v1.7.2
   py34-install-geth-v1.7.2:
     <<: *common_go_v_1_7
     docker:
@@ -144,13 +130,6 @@ jobs:
           GETH_VERSION: v1.7.2
           TOXENV: py35-install-geth-v1.7.2
 
-  py27-install-geth-v1.8.1:
-    <<: *common_go_v_1_7
-    docker:
-      - image: circleci/python:2.7
-        environment:
-          GETH_VERSION: v1.8.1
-          TOXENV: py27-install-geth-v1.8.1
   py34-install-geth-v1.8.1:
     <<: *common_go_v_1_7
     docker:
@@ -166,13 +145,6 @@ jobs:
           GETH_VERSION: v1.8.1
           TOXENV: py35-install-geth-v1.8.1
 
-  py27-install-geth-v1.8.2:
-    <<: *common_go_v_1_10
-    docker:
-      - image: circleci/python:2.7
-        environment:
-          GETH_VERSION: v1.8.2
-          TOXENV: py27-install-geth-v1.8.2
   py34-install-geth-v1.8.2:
     <<: *common_go_v_1_10
     docker:
@@ -188,13 +160,6 @@ jobs:
           GETH_VERSION: v1.8.2
           TOXENV: py35-install-geth-v1.8.2
 
-  py27-install-geth-v1.8.3:
-    <<: *common_go_v_1_10
-    docker:
-      - image: circleci/python:2.7
-        environment:
-          GETH_VERSION: v1.8.3
-          TOXENV: py27-install-geth-v1.8.3
   py34-install-geth-v1.8.3:
     <<: *common_go_v_1_10
     docker:
@@ -210,13 +175,6 @@ jobs:
           GETH_VERSION: v1.8.3
           TOXENV: py35-install-geth-v1.8.3
 
-  py27-install-geth-v1.8.4:
-    <<: *common_go_v_1_10
-    docker:
-      - image: circleci/python:2.7
-        environment:
-          GETH_VERSION: v1.8.4
-          TOXENV: py27-install-geth-v1.8.4
   py34-install-geth-v1.8.4:
     <<: *common_go_v_1_10
     docker:
@@ -232,13 +190,6 @@ jobs:
           GETH_VERSION: v1.8.4
           TOXENV: py35-install-geth-v1.8.4
 
-  py27-install-geth-v1.8.5:
-    <<: *common_go_v_1_10
-    docker:
-      - image: circleci/python:2.7
-        environment:
-          GETH_VERSION: v1.8.5
-          TOXENV: py27-install-geth-v1.8.5
   py34-install-geth-v1.8.5:
     <<: *common_go_v_1_10
     docker:
@@ -254,13 +205,6 @@ jobs:
           GETH_VERSION: v1.8.5
           TOXENV: py35-install-geth-v1.8.5
 
-  py27-install-geth-v1.8.6:
-    <<: *common_go_v_1_10
-    docker:
-      - image: circleci/python:2.7
-        environment:
-          GETH_VERSION: v1.8.6
-          TOXENV: py27-install-geth-v1.8.6
   py34-install-geth-v1.8.6:
     <<: *common_go_v_1_10
     docker:
@@ -276,13 +220,6 @@ jobs:
           GETH_VERSION: v1.8.6
           TOXENV: py35-install-geth-v1.8.6
 
-  py27-install-geth-v1.8.7:
-    <<: *common_go_v_1_10
-    docker:
-      - image: circleci/python:2.7
-        environment:
-          GETH_VERSION: v1.8.7
-          TOXENV: py27-install-geth-v1.8.7
   py34-install-geth-v1.8.7:
     <<: *common_go_v_1_10
     docker:
@@ -298,13 +235,6 @@ jobs:
           GETH_VERSION: v1.8.7
           TOXENV: py35-install-geth-v1.8.7
 
-  py27-install-geth-v1.8.8:
-    <<: *common_go_v_1_10
-    docker:
-      - image: circleci/python:2.7
-        environment:
-          GETH_VERSION: v1.8.8
-          TOXENV: py27-install-geth-v1.8.8
   py34-install-geth-v1.8.8:
     <<: *common_go_v_1_10
     docker:
@@ -320,13 +250,6 @@ jobs:
           GETH_VERSION: v1.8.8
           TOXENV: py35-install-geth-v1.8.8
 
-  py27-install-geth-v1.8.9:
-    <<: *common_go_v_1_10
-    docker:
-      - image: circleci/python:2.7
-        environment:
-          GETH_VERSION: v1.8.9
-          TOXENV: py27-install-geth-v1.8.9
   py34-install-geth-v1.8.9:
     <<: *common_go_v_1_10
     docker:
@@ -342,13 +265,6 @@ jobs:
           GETH_VERSION: v1.8.9
           TOXENV: py35-install-geth-v1.8.9
 
-  py27-install-geth-v1.8.10:
-    <<: *common_go_v_1_10
-    docker:
-      - image: circleci/python:2.7
-        environment:
-          GETH_VERSION: v1.8.10
-          TOXENV: py27-install-geth-v1.8.10
   py34-install-geth-v1.8.10:
     <<: *common_go_v_1_10
     docker:
@@ -364,13 +280,6 @@ jobs:
           GETH_VERSION: v1.8.10
           TOXENV: py35-install-geth-v1.8.10
 
-  py27-install-geth-v1.8.11:
-    <<: *common_go_v_1_10
-    docker:
-      - image: circleci/python:2.7
-        environment:
-          GETH_VERSION: v1.8.11
-          TOXENV: py27-install-geth-v1.8.11
   py34-install-geth-v1.8.11:
     <<: *common_go_v_1_10
     docker:
@@ -386,13 +295,6 @@ jobs:
           GETH_VERSION: v1.8.11
           TOXENV: py35-install-geth-v1.8.11
 
-  py27-install-geth-v1.8.12:
-    <<: *common_go_v_1_10
-    docker:
-      - image: circleci/python:2.7
-        environment:
-          GETH_VERSION: v1.8.12
-          TOXENV: py27-install-geth-v1.8.12
   py34-install-geth-v1.8.12:
     <<: *common_go_v_1_10
     docker:
@@ -408,13 +310,6 @@ jobs:
           GETH_VERSION: v1.8.12
           TOXENV: py35-install-geth-v1.8.12
 
-  py27-install-geth-v1.8.13:
-    <<: *common_go_v_1_10
-    docker:
-      - image: circleci/python:2.7
-        environment:
-          GETH_VERSION: v1.8.13
-          TOXENV: py27-install-geth-v1.8.13
   py34-install-geth-v1.8.13:
     <<: *common_go_v_1_10
     docker:
@@ -430,13 +325,6 @@ jobs:
           GETH_VERSION: v1.8.13
           TOXENV: py35-install-geth-v1.8.13
 
-  py27-install-geth-v1.8.14:
-    <<: *common_go_v_1_10
-    docker:
-      - image: circleci/python:2.7
-        environment:
-          GETH_VERSION: v1.8.14
-          TOXENV: py27-install-geth-v1.8.14
   py34-install-geth-v1.8.14:
     <<: *common_go_v_1_10
     docker:
@@ -452,13 +340,6 @@ jobs:
           GETH_VERSION: v1.8.14
           TOXENV: py35-install-geth-v1.8.14
 
-  py27-install-geth-v1.8.15:
-    <<: *common_go_v_1_10
-    docker:
-      - image: circleci/python:2.7
-        environment:
-          GETH_VERSION: v1.8.15
-          TOXENV: py27-install-geth-v1.8.15
   py34-install-geth-v1.8.15:
     <<: *common_go_v_1_10
     docker:
@@ -474,13 +355,6 @@ jobs:
           GETH_VERSION: v1.8.15
           TOXENV: py35-install-geth-v1.8.15
 
-  py27-install-geth-v1.8.16:
-    <<: *common_go_v_1_10
-    docker:
-      - image: circleci/python:2.7
-        environment:
-          GETH_VERSION: v1.8.16
-          TOXENV: py27-install-geth-v1.8.16
   py34-install-geth-v1.8.16:
     <<: *common_go_v_1_10
     docker:
@@ -496,13 +370,6 @@ jobs:
           GETH_VERSION: v1.8.16
           TOXENV: py35-install-geth-v1.8.16
 
-  py27-install-geth-v1.8.17:
-    <<: *common_go_v_1_10
-    docker:
-      - image: circleci/python:2.7
-        environment:
-          GETH_VERSION: v1.8.17
-          TOXENV: py27-install-geth-v1.8.17
   py34-install-geth-v1.8.17:
     <<: *common_go_v_1_10
     docker:
@@ -518,13 +385,6 @@ jobs:
           GETH_VERSION: v1.8.17
           TOXENV: py35-install-geth-v1.8.17
 
-  py27-install-geth-v1.8.18:
-    <<: *common_go_v_1_10
-    docker:
-      - image: circleci/python:2.7
-        environment:
-          GETH_VERSION: v1.8.18
-          TOXENV: py27-install-geth-v1.8.18
   py34-install-geth-v1.8.18:
     <<: *common_go_v_1_10
     docker:
@@ -540,13 +400,6 @@ jobs:
           GETH_VERSION: v1.8.18
           TOXENV: py35-install-geth-v1.8.18
 
-  py27-install-geth-v1.8.19:
-    <<: *common_go_v_1_10
-    docker:
-      - image: circleci/python:2.7
-        environment:
-          GETH_VERSION: v1.8.19
-          TOXENV: py27-install-geth-v1.8.19
   py34-install-geth-v1.8.19:
     <<: *common_go_v_1_10
     docker:
@@ -562,13 +415,6 @@ jobs:
           GETH_VERSION: v1.8.19
           TOXENV: py35-install-geth-v1.8.19
 
-  py27-install-geth-v1.8.20:
-    <<: *common_go_v_1_10
-    docker:
-      - image: circleci/python:2.7
-        environment:
-          GETH_VERSION: v1.8.20
-          TOXENV: py27-install-geth-v1.8.20
   py34-install-geth-v1.8.20:
     <<: *common_go_v_1_10
     docker:
@@ -584,13 +430,6 @@ jobs:
           GETH_VERSION: v1.8.20
           TOXENV: py35-install-geth-v1.8.20
 
-  py27-install-geth-v1.8.21:
-    <<: *common_go_v_1_10
-    docker:
-      - image: circleci/python:2.7
-        environment:
-          GETH_VERSION: v1.8.21
-          TOXENV: py27-install-geth-v1.8.21
   py34-install-geth-v1.8.21:
     <<: *common_go_v_1_10
     docker:
@@ -606,13 +445,6 @@ jobs:
           GETH_VERSION: v1.8.21
           TOXENV: py35-install-geth-v1.8.21
 
-  py27-install-geth-v1.8.22:
-    <<: *common_go_v_1_10
-    docker:
-      - image: circleci/python:2.7
-        environment:
-          GETH_VERSION: v1.8.22
-          TOXENV: py27-install-geth-v1.8.22
   py34-install-geth-v1.8.22:
     <<: *common_go_v_1_10
     docker:
@@ -628,12 +460,6 @@ jobs:
           GETH_VERSION: v1.8.22
           TOXENV: py35-install-geth-v1.8.22
 
-  py27-lint:
-    <<: *common_go_v_1_7
-    docker:
-      - image: circleci/python:2.7
-        environment:
-          TOXENV: py27-lint
   py34-lint:
     <<: *common_go_v_1_7
     docker:
@@ -652,102 +478,77 @@ workflows:
   version: 2
   test:
     jobs:
-      - py27-install-geth-v1.7.0
       - py34-install-geth-v1.7.0
       - py35-install-geth-v1.7.0
 
-      - py27-install-geth-v1.7.2
       - py34-install-geth-v1.7.2
       - py35-install-geth-v1.7.2
 
-      - py27-install-geth-v1.8.1
       - py34-install-geth-v1.8.1
       - py35-install-geth-v1.8.1
 
-      - py27-install-geth-v1.8.2
       - py34-install-geth-v1.8.2
       - py35-install-geth-v1.8.2
 
-      - py27-install-geth-v1.8.3
       - py34-install-geth-v1.8.3
       - py35-install-geth-v1.8.3
 
-      - py27-install-geth-v1.8.4
       - py34-install-geth-v1.8.4
       - py35-install-geth-v1.8.4
 
-      - py27-install-geth-v1.8.5
       - py34-install-geth-v1.8.5
       - py35-install-geth-v1.8.5
 
-      - py27-install-geth-v1.8.6
       - py34-install-geth-v1.8.6
       - py35-install-geth-v1.8.6
 
-      - py27-install-geth-v1.8.7
       - py34-install-geth-v1.8.7
       - py35-install-geth-v1.8.7
 
-      - py27-install-geth-v1.8.8
       - py34-install-geth-v1.8.8
       - py35-install-geth-v1.8.8
 
-      - py27-install-geth-v1.8.9
       - py34-install-geth-v1.8.9
       - py35-install-geth-v1.8.9
 
-      - py27-install-geth-v1.8.10
       - py34-install-geth-v1.8.10
       - py35-install-geth-v1.8.10
 
-      - py27-install-geth-v1.8.11
       - py34-install-geth-v1.8.11
       - py35-install-geth-v1.8.11
 
-      - py27-install-geth-v1.8.12
       - py34-install-geth-v1.8.12
       - py35-install-geth-v1.8.12
 
-      - py27-install-geth-v1.8.13
       - py34-install-geth-v1.8.13
       - py35-install-geth-v1.8.13
 
-      - py27-install-geth-v1.8.14
       - py34-install-geth-v1.8.14
       - py35-install-geth-v1.8.14
 
-      - py27-install-geth-v1.8.15
       - py34-install-geth-v1.8.15
       - py35-install-geth-v1.8.15
 
-      - py27-install-geth-v1.8.16
       - py34-install-geth-v1.8.16
       - py35-install-geth-v1.8.16
 
-      - py27-install-geth-v1.8.17
       - py34-install-geth-v1.8.17
       - py35-install-geth-v1.8.17
 
-      - py27-install-geth-v1.8.18
       - py34-install-geth-v1.8.18
       - py35-install-geth-v1.8.18
 
-      - py27-install-geth-v1.8.19
       - py34-install-geth-v1.8.19
       - py35-install-geth-v1.8.19
 
-      - py27-install-geth-v1.8.20
       - py34-install-geth-v1.8.20
       - py35-install-geth-v1.8.20
 
-      - py27-install-geth-v1.8.21
       - py34-install-geth-v1.8.21
       - py35-install-geth-v1.8.21
 
-      - py27-install-geth-v1.8.22
       - py34-install-geth-v1.8.22
       - py35-install-geth-v1.8.22
 
-      - py27-lint
       - py34-lint
       - py35-lint

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # Packages
 *.egg
+*.eggs
 *.egg-info
 dist
 build
@@ -27,6 +28,7 @@ pip-log.txt
 .tox
 nosetests.xml
 .cache
+.pytest_cache
 
 # Translations
 *.mo

--- a/geth/__init__.py
+++ b/geth/__init__.py
@@ -1,6 +1,4 @@
 import pkg_resources
-import sys
-import warnings
 
 from .main import (  # noqa: F401
     get_geth_version,
@@ -19,14 +17,6 @@ from .mixins import (  # noqa: F401
     InterceptedStreamsMixin,
     LoggingMixin,
 )
-
-
-if sys.version_info.major < 3:
-    warnings.simplefilter('always', DeprecationWarning)
-    warnings.warn(DeprecationWarning(
-        "The `py-geth` library is dropping support for Python 2.  Upgrade to Python 3."
-    ))
-    warnings.resetwarnings()
 
 
 __version__ = pkg_resources.get_distribution("py-geth").version

--- a/geth/mixins.py
+++ b/geth/mixins.py
@@ -3,13 +3,7 @@ from __future__ import absolute_import
 import datetime
 import logging
 import os
-
-try:
-    import queue
-except ImportError:
-    # python 2 support
-    import Queue as queue
-
+import queue
 import time
 
 from geth.utils.filesystem import ensure_path_exists

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,0 @@
-pytest>=2.9.2
-tox>=2.3.1
-requests==2.10.0
-flaky==3.2.0
-flake8==3.0.4
-bumpversion>=0.5.3,<1.0.0

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
     install_requires=[
         "semantic-version>=2.6.0",
     ],
+    python_requires=">=3",
     extras_require=deps,
     setup_requires=['setuptools-markdown'],
     license="MIT",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{27,34,35}-lint
-    py{27,34,35}-install-geth-{v1.7.0, v1.7.2, v1.8.1, v1.8.2, v1.8.3, v1.8.4, v1.8.5, v1.8.6, v1.8.7, v1.8.8, v1.8.9, v1.8.10, v1.8.11, v1.8.12, v1.8.13, v1.8.14, v1.8.15, v1.8.16, v1.8.17, v1.8.18, v1.8.19, v1.8.20, v1.8.21, v1.8.22}
+    py{34,35}-lint
+    py{34,35}-install-geth-{v1.7.0, v1.7.2, v1.8.1, v1.8.2, v1.8.3, v1.8.4, v1.8.5, v1.8.6, v1.8.7, v1.8.8, v1.8.9, v1.8.10, v1.8.11, v1.8.12, v1.8.13, v1.8.14, v1.8.15, v1.8.16, v1.8.17, v1.8.18, v1.8.19, v1.8.20, v1.8.21, v1.8.22}
 
 
 [flake8]
@@ -27,7 +27,6 @@ deps =
     .[test]
     install-geth: {[common_geth_installation_and_check]deps}
 basepython =
-    py27: python2.7
     py34: python3.4
     py35: python3.5
 
@@ -45,11 +44,6 @@ deps = .[lint]
 setenv = MYPYPATH={toxinidir}:{toxinidir}/stubs
 commands =
     flake8 {toxinidir}/geth
-
-[testenv:py27-lint]
-deps = {[common-lint]deps}
-setenv = {[common-lint]setenv}
-commands = {[common-lint]commands}
 
 [testenv:py34-lint]
 deps = {[common-lint]deps}


### PR DESCRIPTION
### What was wrong?
Fixes #51 


### How was it fixed?
`python_requires` constraint was added to `setup.py` and other stuff related to `python2` was removed from the codebase. Further the testing of the library wrt to `python2` has been removed from `Circle CI`.


#### Cute Animal Picture

![Cute Animal Picture](http://smilebigpeaches.weebly.com/uploads/1/5/2/6/15266094/2369313_orig.jpg?0)
