### PR TITLE
fix: pass along stderr argument

### DIFF
--- a/geth/install.py
+++ b/geth/install.py
@@ -114,7 +114,7 @@ def check_subprocess_output(command, message=None, stderr=subprocess.STDOUT, **p
 
     return subprocess.check_output(
         command,
-        stderr=subprocess.STDOUT,
+        stderr=stderr,
         **proc_kwargs
     )
 


### PR DESCRIPTION
### What was wrong?

Was not passing `stderr` into called method

### How was it fixed?

pass along the argument to the called method

#### Cute Animal Picture

![baby-coyote-yawning-peggy-collins](https://user-images.githubusercontent.com/19540978/138458566-7ffae020-25a1-4329-8184-57efb869f7d9.jpeg)


