### PR TITLE
fix: resolve Popen warning by removing bufsize=1

### DIFF
--- a/geth/wrapper.py
+++ b/geth/wrapper.py
@@ -280,7 +280,6 @@ def spawn_geth(geth_kwargs,
         stdin=stdin,
         stdout=stdout,
         stderr=stderr,
-        bufsize=1,
     )
 
     return command, proc


### PR DESCRIPTION
### What was wrong?

Was getting a warning about using bufsize=1 when calling `Popen()`:

```
RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used
```

From what I can tell, `bufsize=1` when piping to a binary was never actually a thing and that previousy `bufsize` defaulted to `0` and that had caused problems (maybe why it was set to `1` here?)

From `Popen` docs:

```
Changed in version 3.3.1: bufsize now defaults to -1 to enable buffering by default to match the behavior that most code expects. In versions prior to Python 3.2.4 and 3.3.1 it incorrectly defaulted to 0 which was unbuffered and allowed short reads. This was unintentional and did not match the behavior of Python 2 as most code expected.
```

Thus, the default is `-1` should buffer reasonably?

Let me know if I am incorrect.



### How was it fixed?



#### Cute Animal Picture

![Baby-moose](https://user-images.githubusercontent.com/19540978/138476875-4f69819e-080e-4032-9898-a2b351255e6a.jpeg)

