### PR TITLE
fix: handle StopIteration in JoinableQueues

### DIFF
--- a/geth/mixins.py
+++ b/geth/mixins.py
@@ -50,10 +50,17 @@ class JoinableQueue(queue.Queue):
     def __iter__(self):
         while True:
             item = self.get()
-            if isinstance(item, Exception):
+
+            is_stop_iteration_type = isinstance(item, type) and issubclass(item, StopIteration)
+            if isinstance(item, StopIteration) or is_stop_iteration_type:
+                return
+
+            elif isinstance(item, Exception):
                 raise item
+
             elif isinstance(item, type) and issubclass(item, Exception):
                 raise item
+
             yield item
 
     def join(self, timeout=None):

--- a/tests/core/running/test_running_with_logging.py
+++ b/tests/core/running/test_running_with_logging.py
@@ -1,5 +1,32 @@
+import pytest
+import threading
+import sys
+
 from geth import DevGethProcess
 from geth.mixins import LoggingMixin
+
+_ERRORS = []
+
+
+@pytest.fixture(autouse=True)
+def fail_from_errors_on_other_threads():
+    # Set excepthook to catch errors in child threads.
+    global _ERRORS
+    _ERRORS = []
+
+    def pytest_excepthook(*args, **kwargs):
+        global _ERRORS
+        _ERRORS.extend(args)
+
+    sys.excepthook = pytest_excepthook
+    threading.excepthook = pytest_excepthook
+
+    yield
+
+    sys.excepthook = sys.__excepthook__
+    if _ERRORS:
+        caught_errors_str = ', '.join([str(err) for err in _ERRORS])
+        pytest.fail(f'Caught exceptions from other threads :\n{caught_errors_str}')
 
 
 class WithLogging(LoggingMixin, DevGethProcess):

--- a/tests/core/running/test_running_with_logging.py
+++ b/tests/core/running/test_running_with_logging.py
@@ -9,7 +9,10 @@ _errors = []
 
 @pytest.fixture(autouse=True)
 def fail_from_errors_on_other_threads():
-    # Set excepthook to catch errors in child threads.
+    """
+    Causes errors when `LoggingMixing` is improperly implemented.
+    Useful for preventing false-positives in logging-based tests.
+    """
 
     def pytest_excepthook(*args, **kwargs):
         _errors.extend(args)

--- a/tests/core/running/test_running_with_logging.py
+++ b/tests/core/running/test_running_with_logging.py
@@ -4,25 +4,22 @@ import threading
 from geth import DevGethProcess
 from geth.mixins import LoggingMixin
 
-_ERRORS = []
+_errors = []
 
 
 @pytest.fixture(autouse=True)
 def fail_from_errors_on_other_threads():
     # Set excepthook to catch errors in child threads.
-    global _ERRORS
-    _ERRORS = []
 
     def pytest_excepthook(*args, **kwargs):
-        global _ERRORS
-        _ERRORS.extend(args)
+        _errors.extend(args)
 
     threading.excepthook = pytest_excepthook
 
     yield
 
-    if _ERRORS:
-        caught_errors_str = ', '.join([str(err) for err in _ERRORS])
+    if _errors:
+        caught_errors_str = ', '.join([str(err) for err in _errors])
         pytest.fail(f'Caught exceptions from other threads:\n{caught_errors_str}')
 
 

--- a/tests/core/running/test_running_with_logging.py
+++ b/tests/core/running/test_running_with_logging.py
@@ -1,6 +1,5 @@
 import pytest
 import threading
-import sys
 
 from geth import DevGethProcess
 from geth.mixins import LoggingMixin
@@ -18,15 +17,13 @@ def fail_from_errors_on_other_threads():
         global _ERRORS
         _ERRORS.extend(args)
 
-    sys.excepthook = pytest_excepthook
     threading.excepthook = pytest_excepthook
 
     yield
 
-    sys.excepthook = sys.__excepthook__
     if _ERRORS:
         caught_errors_str = ', '.join([str(err) for err in _ERRORS])
-        pytest.fail(f'Caught exceptions from other threads :\n{caught_errors_str}')
+        pytest.fail(f'Caught exceptions from other threads:\n{caught_errors_str}')
 
 
 class WithLogging(LoggingMixin, DevGethProcess):

--- a/tests/core/running/test_running_with_logging.py
+++ b/tests/core/running/test_running_with_logging.py
@@ -10,7 +10,7 @@ _errors = []
 @pytest.fixture(autouse=True)
 def fail_from_errors_on_other_threads():
     """
-    Causes errors when `LoggingMixing` is improperly implemented.
+    Causes errors when `LoggingMixin` is improperly implemented.
     Useful for preventing false-positives in logging-based tests.
     """
 


### PR DESCRIPTION
### What was wrong?

When using the `LoggingMixin` class, it always errors with `StopIteration`. My understanding is that `StopIteration` gets raised by `next()` when `iter` is done. I guess we should probably just stop iterating at that point rather than crash the program.

### How was it fixed?

Checking for `StopIteration` type or value and exiting the daemon method.

#### Cute Animal Picture

![baby_squirrel](https://user-images.githubusercontent.com/19540978/139126914-948df89f-37e7-407a-9228-0f1afb5dafea.jpeg)
