### PR TITLE
fix: remote double formatted log lines from LoggingMixin

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+Unreleased
+-----
+
+- Remove extraneous logging formatting from the LoggingMixin
+
 3.6.0
 -----
 

--- a/geth/mixins.py
+++ b/geth/mixins.py
@@ -25,7 +25,7 @@ def construct_logger_file_path(prefix, suffix):
     return os.path.join('logs', timestamp)
 
 
-def get_file_logger(name, filename):
+def get_file_logger(name, filename, formatter=None):
     # create logger with 'spam_application'
     logger = logging.getLogger(name)
     logger.setLevel(logging.DEBUG)
@@ -36,7 +36,7 @@ def get_file_logger(name, filename):
     ch = logging.StreamHandler()
     ch.setLevel(logging.ERROR)
     # create formatter and add it to the handlers
-    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    formatter = formatter or logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
     fh.setFormatter(formatter)
     ch.setFormatter(formatter)
     # add the handlers to the logger
@@ -154,8 +154,14 @@ class LoggingMixin(InterceptedStreamsMixin):
 
         super(LoggingMixin, self).__init__(*args, **kwargs)
 
-        stdout_logger = get_file_logger('geth-stdout', stdout_logfile_path)
-        stderr_logger = get_file_logger('geth-stderr', stderr_logfile_path)
+        clean_formatter = logging.Formatter('%(message)s')
+
+        stdout_logger = get_file_logger(
+            'geth-stdout', stdout_logfile_path, formatter=clean_formatter
+        )
+        stderr_logger = get_file_logger(
+            'geth-stderr', stderr_logfile_path, formatter=clean_formatter
+        )
 
         self.register_stdout_callback(stdout_logger.info)
         self.register_stderr_callback(stderr_logger.info)

--- a/geth/mixins.py
+++ b/geth/mixins.py
@@ -25,7 +25,7 @@ def construct_logger_file_path(prefix, suffix):
     return os.path.join('logs', timestamp)
 
 
-def get_file_logger(name, filename, formatter=None):
+def get_file_logger(name, filename, log_format=None):
     # create logger with 'spam_application'
     logger = logging.getLogger(name)
     logger.setLevel(logging.DEBUG)
@@ -36,7 +36,8 @@ def get_file_logger(name, filename, formatter=None):
     ch = logging.StreamHandler()
     ch.setLevel(logging.ERROR)
     # create formatter and add it to the handlers
-    formatter = formatter or logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    default_log_format = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    formatter = logging.Formatter(log_format or default_log_format)
     fh.setFormatter(formatter)
     ch.setFormatter(formatter)
     # add the handlers to the logger
@@ -154,13 +155,11 @@ class LoggingMixin(InterceptedStreamsMixin):
 
         super(LoggingMixin, self).__init__(*args, **kwargs)
 
-        clean_formatter = logging.Formatter('%(message)s')
-
         stdout_logger = get_file_logger(
-            'geth-stdout', stdout_logfile_path, formatter=clean_formatter
+            'geth-stdout', stdout_logfile_path, log_format='%(message)s'
         )
         stderr_logger = get_file_logger(
-            'geth-stderr', stderr_logfile_path, formatter=clean_formatter
+            'geth-stderr', stderr_logfile_path, log_format='%(message)s'
         )
 
         self.register_stdout_callback(stdout_logger.info)

--- a/geth/mixins.py
+++ b/geth/mixins.py
@@ -25,7 +25,7 @@ def construct_logger_file_path(prefix, suffix):
     return os.path.join('logs', timestamp)
 
 
-def get_file_logger(name, filename, log_format=None):
+def _get_file_logger(name, filename):
     # create logger with 'spam_application'
     logger = logging.getLogger(name)
     logger.setLevel(logging.DEBUG)
@@ -36,8 +36,7 @@ def get_file_logger(name, filename, log_format=None):
     ch = logging.StreamHandler()
     ch.setLevel(logging.ERROR)
     # create formatter and add it to the handlers
-    default_log_format = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-    formatter = logging.Formatter(log_format or default_log_format)
+    formatter = logging.Formatter('%(message)s')
     fh.setFormatter(formatter)
     ch.setFormatter(formatter)
     # add the handlers to the logger
@@ -155,12 +154,8 @@ class LoggingMixin(InterceptedStreamsMixin):
 
         super(LoggingMixin, self).__init__(*args, **kwargs)
 
-        stdout_logger = get_file_logger(
-            'geth-stdout', stdout_logfile_path, log_format='%(message)s'
-        )
-        stderr_logger = get_file_logger(
-            'geth-stderr', stderr_logfile_path, log_format='%(message)s'
-        )
+        stdout_logger = _get_file_logger('geth-stdout', stdout_logfile_path)
+        stderr_logger = _get_file_logger('geth-stderr', stderr_logfile_path)
 
         self.register_stdout_callback(stdout_logger.info)
         self.register_stderr_callback(stderr_logger.info)

--- a/tests/core/running/test_running_with_logging.py
+++ b/tests/core/running/test_running_with_logging.py
@@ -30,12 +30,34 @@ class WithLogging(LoggingMixin, DevGethProcess):
     pass
 
 
-def test_with_logging(base_dir):
-    geth = WithLogging('testing', base_dir=base_dir)
+def test_with_logging(base_dir, caplog):
+    test_stdout_path = f'{base_dir}/testing/stdoutlogs.log'
+    test_stderr_path = f'{base_dir}/testing/stderrlogs.log'
+
+    geth = WithLogging(
+        'testing',
+        base_dir=base_dir,
+        stdout_logfile_path=test_stdout_path,
+        stderr_logfile_path=test_stderr_path
+    )
 
     geth.start()
 
     assert geth.is_running
     assert geth.is_alive
+
+    stdout_logger_info = geth.stdout_callbacks[0]
+    stderr_logger_info = geth.stderr_callbacks[0]
+
+    stdout_logger_info("test_out")
+    stderr_logger_info("test_err")
+
+    with open(test_stdout_path) as out_log_file:
+        line = out_log_file.readline()
+        assert line == "test_out\n"
+
+    with open(test_stderr_path) as err_log_file:
+        line = err_log_file.readline()
+        assert line == "test_err\n"
 
     geth.stop()


### PR DESCRIPTION
### What was wrong?

fixes: #82 

### How was it fixed?

Cut out the formatter for the file loggers. Now, when tailing the log files, you only see the log information from geth.

#### Cute Animal Picture

![toy_elephant](https://user-images.githubusercontent.com/19540978/142470939-d738d94f-686f-4d78-9122-148fb7a1032f.jpeg)
