### PR TITLE
docs: Change comment to say `geth` and not `solc`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+Unreleased
+-----
+
+ - fix incorrect comment in `install_geth.sh`
+
 3.10.0
 ------
 

--- a/bin/install_geth.sh
+++ b/bin/install_geth.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Install solc 
+# Install geth
 #
 
 set -e


### PR DESCRIPTION
### What was wrong?

Comment said `solc` instead of `geth`.

### How was it fixed?

Changed it to `geth`

#### Cute Animal Picture

![chicken](https://user-images.githubusercontent.com/19540978/200356151-b06badbf-2b7b-4d7d-91fc-337e67c38d53.gif)

