### PR TITLE
Upgrade circleci go version to `1.20.1`; Add support for `py311`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,13 @@ jobs:
         environment:
           GETH_VERSION: v1.10.0
           TOXENV: py310-install-geth-v1.10.0
+  py311-install-geth-v1.10.0:
+    <<: *common_go_v_1_20_1
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          GETH_VERSION: v1.10.0
+          TOXENV: py311-install-geth-v1.10.0
   py37-install-geth-v1.10.1:
     <<: *common_go_v_1_20_1
     docker:
@@ -108,6 +115,13 @@ jobs:
         environment:
           GETH_VERSION: v1.10.1
           TOXENV: py310-install-geth-v1.10.1
+  py311-install-geth-v1.10.1:
+    <<: *common_go_v_1_20_1
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          GETH_VERSION: v1.10.1
+          TOXENV: py311-install-geth-v1.10.1
   py37-install-geth-v1.10.2:
     <<: *common_go_v_1_20_1
     docker:
@@ -136,6 +150,13 @@ jobs:
         environment:
           GETH_VERSION: v1.10.2
           TOXENV: py310-install-geth-v1.10.2
+  py311-install-geth-v1.10.2:
+    <<: *common_go_v_1_20_1
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          GETH_VERSION: v1.10.2
+          TOXENV: py311-install-geth-v1.10.2
   py37-install-geth-v1.10.3:
     <<: *common_go_v_1_20_1
     docker:
@@ -164,6 +185,13 @@ jobs:
         environment:
           GETH_VERSION: v1.10.3
           TOXENV: py310-install-geth-v1.10.3
+  py311-install-geth-v1.10.3:
+    <<: *common_go_v_1_20_1
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          GETH_VERSION: v1.10.3
+          TOXENV: py311-install-geth-v1.10.3
   py37-install-geth-v1.10.4:
     <<: *common_go_v_1_20_1
     docker:
@@ -192,6 +220,13 @@ jobs:
         environment:
           GETH_VERSION: v1.10.4
           TOXENV: py310-install-geth-v1.10.4
+  py311-install-geth-v1.10.4:
+    <<: *common_go_v_1_20_1
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          GETH_VERSION: v1.10.4
+          TOXENV: py311-install-geth-v1.10.4
   py37-install-geth-v1.10.5:
     <<: *common_go_v_1_20_1
     docker:
@@ -220,6 +255,13 @@ jobs:
         environment:
           GETH_VERSION: v1.10.5
           TOXENV: py310-install-geth-v1.10.5
+  py311-install-geth-v1.10.5:
+    <<: *common_go_v_1_20_1
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          GETH_VERSION: v1.10.5
+          TOXENV: py311-install-geth-v1.10.5
   py37-install-geth-v1.10.6:
     <<: *common_go_v_1_20_1
     docker:
@@ -248,6 +290,13 @@ jobs:
         environment:
           GETH_VERSION: v1.10.6
           TOXENV: py310-install-geth-v1.10.6
+  py311-install-geth-v1.10.6:
+    <<: *common_go_v_1_20_1
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          GETH_VERSION: v1.10.6
+          TOXENV: py311-install-geth-v1.10.6
   py37-install-geth-v1.10.7:
     <<: *common_go_v_1_20_1
     docker:
@@ -276,6 +325,13 @@ jobs:
         environment:
           GETH_VERSION: v1.10.7
           TOXENV: py310-install-geth-v1.10.7
+  py311-install-geth-v1.10.7:
+    <<: *common_go_v_1_20_1
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          GETH_VERSION: v1.10.7
+          TOXENV: py311-install-geth-v1.10.7
   py37-install-geth-v1.10.8:
     <<: *common_go_v_1_20_1
     docker:
@@ -304,6 +360,13 @@ jobs:
         environment:
           GETH_VERSION: v1.10.8
           TOXENV: py310-install-geth-v1.10.8
+  py311-install-geth-v1.10.8:
+    <<: *common_go_v_1_20_1
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          GETH_VERSION: v1.10.8
+          TOXENV: py311-install-geth-v1.10.8
   py37-install-geth-v1.10.9:
     <<: *common_go_v_1_20_1
     docker:
@@ -332,6 +395,13 @@ jobs:
         environment:
           GETH_VERSION: v1.10.9
           TOXENV: py310-install-geth-v1.10.9
+  py311-install-geth-v1.10.9:
+    <<: *common_go_v_1_20_1
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          GETH_VERSION: v1.10.9
+          TOXENV: py311-install-geth-v1.10.9
   py37-install-geth-v1.10.10:
     <<: *common_go_v_1_20_1
     docker:
@@ -360,6 +430,13 @@ jobs:
         environment:
           GETH_VERSION: v1.10.10
           TOXENV: py310-install-geth-v1.10.10
+  py311-install-geth-v1.10.10:
+    <<: *common_go_v_1_20_1
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          GETH_VERSION: v1.10.10
+          TOXENV: py311-install-geth-v1.10.10
   py37-install-geth-v1.10.11:
     <<: *common_go_v_1_20_1
     docker:
@@ -388,6 +465,13 @@ jobs:
         environment:
           GETH_VERSION: v1.10.11
           TOXENV: py310-install-geth-v1.10.11
+  py311-install-geth-v1.10.11:
+    <<: *common_go_v_1_20_1
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          GETH_VERSION: v1.10.11
+          TOXENV: py311-install-geth-v1.10.11
   py37-install-geth-v1.10.12:
     <<: *common_go_v_1_20_1
     docker:
@@ -416,6 +500,13 @@ jobs:
         environment:
           GETH_VERSION: v1.10.12
           TOXENV: py310-install-geth-v1.10.12
+  py311-install-geth-v1.10.12:
+    <<: *common_go_v_1_20_1
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          GETH_VERSION: v1.10.12
+          TOXENV: py311-install-geth-v1.10.12
   py37-install-geth-v1.10.13:
     <<: *common_go_v_1_20_1
     docker:
@@ -444,6 +535,13 @@ jobs:
         environment:
           GETH_VERSION: v1.10.13
           TOXENV: py310-install-geth-v1.10.13
+  py311-install-geth-v1.10.13:
+    <<: *common_go_v_1_20_1
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          GETH_VERSION: v1.10.13
+          TOXENV: py311-install-geth-v1.10.13
   py37-install-geth-v1.10.14:
     <<: *common_go_v_1_20_1
     docker:
@@ -472,6 +570,13 @@ jobs:
         environment:
           GETH_VERSION: v1.10.14
           TOXENV: py310-install-geth-v1.10.14
+  py311-install-geth-v1.10.14:
+    <<: *common_go_v_1_20_1
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          GETH_VERSION: v1.10.14
+          TOXENV: py311-install-geth-v1.10.14
   py37-install-geth-v1.10.15:
     <<: *common_go_v_1_20_1
     docker:
@@ -500,6 +605,13 @@ jobs:
         environment:
           GETH_VERSION: v1.10.15
           TOXENV: py310-install-geth-v1.10.15
+  py311-install-geth-v1.10.15:
+    <<: *common_go_v_1_20_1
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          GETH_VERSION: v1.10.15
+          TOXENV: py311-install-geth-v1.10.15
   py37-install-geth-v1.10.16:
     <<: *common_go_v_1_20_1
     docker:
@@ -528,6 +640,13 @@ jobs:
         environment:
           GETH_VERSION: v1.10.16
           TOXENV: py310-install-geth-v1.10.16
+  py311-install-geth-v1.10.16:
+    <<: *common_go_v_1_20_1
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          GETH_VERSION: v1.10.16
+          TOXENV: py311-install-geth-v1.10.16
   py37-install-geth-v1.10.17:
     <<: *common_go_v_1_20_1
     docker:
@@ -556,6 +675,13 @@ jobs:
         environment:
           GETH_VERSION: v1.10.17
           TOXENV: py310-install-geth-v1.10.17
+  py311-install-geth-v1.10.17:
+    <<: *common_go_v_1_20_1
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          GETH_VERSION: v1.10.17
+          TOXENV: py311-install-geth-v1.10.17
   py37-install-geth-v1.10.18:
     <<: *common_go_v_1_20_1
     docker:
@@ -584,6 +710,13 @@ jobs:
         environment:
           GETH_VERSION: v1.10.18
           TOXENV: py310-install-geth-v1.10.18
+  py311-install-geth-v1.10.18:
+    <<: *common_go_v_1_20_1
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          GETH_VERSION: v1.10.18
+          TOXENV: py311-install-geth-v1.10.18
   py37-install-geth-v1.10.19:
     <<: *common_go_v_1_20_1
     docker:
@@ -612,6 +745,13 @@ jobs:
         environment:
           GETH_VERSION: v1.10.19
           TOXENV: py310-install-geth-v1.10.19
+  py311-install-geth-v1.10.19:
+    <<: *common_go_v_1_20_1
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          GETH_VERSION: v1.10.19
+          TOXENV: py311-install-geth-v1.10.19
   py37-install-geth-v1.10.20:
     <<: *common_go_v_1_20_1
     docker:
@@ -640,6 +780,13 @@ jobs:
         environment:
           GETH_VERSION: v1.10.20
           TOXENV: py310-install-geth-v1.10.20
+  py311-install-geth-v1.10.20:
+    <<: *common_go_v_1_20_1
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          GETH_VERSION: v1.10.20
+          TOXENV: py311-install-geth-v1.10.20
   py37-install-geth-v1.10.21:
     <<: *common_go_v_1_20_1
     docker:
@@ -668,6 +815,13 @@ jobs:
         environment:
           GETH_VERSION: v1.10.21
           TOXENV: py310-install-geth-v1.10.21
+  py311-install-geth-v1.10.21:
+    <<: *common_go_v_1_20_1
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          GETH_VERSION: v1.10.21
+          TOXENV: py311-install-geth-v1.10.21
   py37-install-geth-v1.10.22:
     <<: *common_go_v_1_20_1
     docker:
@@ -696,6 +850,13 @@ jobs:
         environment:
           GETH_VERSION: v1.10.22
           TOXENV: py310-install-geth-v1.10.22
+  py311-install-geth-v1.10.22:
+    <<: *common_go_v_1_20_1
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          GETH_VERSION: v1.10.22
+          TOXENV: py311-install-geth-v1.10.22
   py37-install-geth-v1.10.23:
     <<: *common_go_v_1_20_1
     docker:
@@ -724,6 +885,13 @@ jobs:
         environment:
           GETH_VERSION: v1.10.23
           TOXENV: py310-install-geth-v1.10.23
+  py311-install-geth-v1.10.23:
+    <<: *common_go_v_1_20_1
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          GETH_VERSION: v1.10.23
+          TOXENV: py311-install-geth-v1.10.23
   py37-install-geth-v1.10.24:
     <<: *common_go_v_1_20_1
     docker:
@@ -752,6 +920,13 @@ jobs:
         environment:
           GETH_VERSION: v1.10.24
           TOXENV: py310-install-geth-v1.10.24
+  py311-install-geth-v1.10.24:
+    <<: *common_go_v_1_20_1
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          GETH_VERSION: v1.10.24
+          TOXENV: py311-install-geth-v1.10.24
   py37-install-geth-v1.10.25:
     <<: *common_go_v_1_20_1
     docker:
@@ -780,6 +955,13 @@ jobs:
         environment:
           GETH_VERSION: v1.10.25
           TOXENV: py310-install-geth-v1.10.25
+  py311-install-geth-v1.10.25:
+    <<: *common_go_v_1_20_1
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          GETH_VERSION: v1.10.25
+          TOXENV: py311-install-geth-v1.10.25
   py37-install-geth-v1.10.26:
     <<: *common_go_v_1_20_1
     docker:
@@ -808,6 +990,13 @@ jobs:
         environment:
           GETH_VERSION: v1.10.26
           TOXENV: py310-install-geth-v1.10.26
+  py311-install-geth-v1.10.26:
+    <<: *common_go_v_1_20_1
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          GETH_VERSION: v1.10.26
+          TOXENV: py311-install-geth-v1.10.26
   py37-install-geth-v1.11.0:
     <<: *common_go_v_1_20_1
     docker:
@@ -836,6 +1025,13 @@ jobs:
         environment:
           GETH_VERSION: v1.11.0
           TOXENV: py310-install-geth-v1.11.0
+  py311-install-geth-v1.11.0:
+    <<: *common_go_v_1_20_1
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          GETH_VERSION: v1.11.0
+          TOXENV: py311-install-geth-v1.11.0
   py37-install-geth-v1.11.1:
     <<: *common_go_v_1_20_1
     docker:
@@ -864,6 +1060,13 @@ jobs:
         environment:
           GETH_VERSION: v1.11.1
           TOXENV: py310-install-geth-v1.11.1
+  py311-install-geth-v1.11.1:
+    <<: *common_go_v_1_20_1
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          GETH_VERSION: v1.11.1
+          TOXENV: py311-install-geth-v1.11.1
   py37-install-geth-v1.11.2:
     <<: *common_go_v_1_20_1
     docker:
@@ -892,6 +1095,13 @@ jobs:
         environment:
           GETH_VERSION: v1.11.2
           TOXENV: py310-install-geth-v1.11.2
+  py311-install-geth-v1.11.2:
+    <<: *common_go_v_1_20_1
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          GETH_VERSION: v1.11.2
+          TOXENV: py311-install-geth-v1.11.2
 
   py37-lint:
     <<: *common_go_v_1_20_1
@@ -917,6 +1127,12 @@ jobs:
       - image: cimg/python:3.10
         environment:
           TOXENV: py310-lint
+  py311-lint:
+    <<: *common_go_v_1_20_1
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          TOXENV: py311-lint
 
 
 workflows:
@@ -927,153 +1143,184 @@ workflows:
       - py38-install-geth-v1.10.0
       - py39-install-geth-v1.10.0
       - py310-install-geth-v1.10.0
+      - py311-install-geth-v1.10.0
 
       - py37-install-geth-v1.10.1
       - py38-install-geth-v1.10.1
       - py39-install-geth-v1.10.1
       - py310-install-geth-v1.10.1
+      - py311-install-geth-v1.10.1
 
       - py37-install-geth-v1.10.2
       - py38-install-geth-v1.10.2
       - py39-install-geth-v1.10.2
       - py310-install-geth-v1.10.2
+      - py311-install-geth-v1.10.2
 
       - py37-install-geth-v1.10.3
       - py38-install-geth-v1.10.3
       - py39-install-geth-v1.10.3
       - py310-install-geth-v1.10.3
+      - py311-install-geth-v1.10.3
 
       - py37-install-geth-v1.10.4
       - py38-install-geth-v1.10.4
       - py39-install-geth-v1.10.4
       - py310-install-geth-v1.10.4
+      - py311-install-geth-v1.10.4
 
       - py37-install-geth-v1.10.5
       - py38-install-geth-v1.10.5
       - py39-install-geth-v1.10.5
       - py310-install-geth-v1.10.5
+      - py311-install-geth-v1.10.5
 
       - py37-install-geth-v1.10.6
       - py38-install-geth-v1.10.6
       - py39-install-geth-v1.10.6
       - py310-install-geth-v1.10.6
+      - py311-install-geth-v1.10.6
 
       - py37-install-geth-v1.10.7
       - py38-install-geth-v1.10.7
       - py39-install-geth-v1.10.7
       - py310-install-geth-v1.10.7
+      - py311-install-geth-v1.10.7
 
       - py37-install-geth-v1.10.8
       - py38-install-geth-v1.10.8
       - py39-install-geth-v1.10.8
       - py310-install-geth-v1.10.8
+      - py311-install-geth-v1.10.8
 
       - py37-install-geth-v1.10.9
       - py38-install-geth-v1.10.9
       - py39-install-geth-v1.10.9
       - py310-install-geth-v1.10.9
+      - py311-install-geth-v1.10.9
 
       - py37-install-geth-v1.10.10
       - py38-install-geth-v1.10.10
       - py39-install-geth-v1.10.10
       - py310-install-geth-v1.10.10
+      - py311-install-geth-v1.10.10
 
       - py37-install-geth-v1.10.11
       - py38-install-geth-v1.10.11
       - py39-install-geth-v1.10.11
       - py310-install-geth-v1.10.11
+      - py311-install-geth-v1.10.11
 
       - py37-install-geth-v1.10.12
       - py38-install-geth-v1.10.12
       - py39-install-geth-v1.10.12
       - py310-install-geth-v1.10.12
+      - py311-install-geth-v1.10.12
 
       - py37-install-geth-v1.10.13
       - py38-install-geth-v1.10.13
       - py39-install-geth-v1.10.13
       - py310-install-geth-v1.10.13
+      - py311-install-geth-v1.10.13
 
       - py37-install-geth-v1.10.14
       - py38-install-geth-v1.10.14
       - py39-install-geth-v1.10.14
       - py310-install-geth-v1.10.14
+      - py311-install-geth-v1.10.14
 
       - py37-install-geth-v1.10.15
       - py38-install-geth-v1.10.15
       - py39-install-geth-v1.10.15
       - py310-install-geth-v1.10.15
+      - py311-install-geth-v1.10.15
 
       - py37-install-geth-v1.10.16
       - py38-install-geth-v1.10.16
       - py39-install-geth-v1.10.16
       - py310-install-geth-v1.10.16
+      - py311-install-geth-v1.10.16
 
       - py37-install-geth-v1.10.17
       - py38-install-geth-v1.10.17
       - py39-install-geth-v1.10.17
       - py310-install-geth-v1.10.17
+      - py311-install-geth-v1.10.17
 
       - py37-install-geth-v1.10.18
       - py38-install-geth-v1.10.18
       - py39-install-geth-v1.10.18
       - py310-install-geth-v1.10.18
+      - py311-install-geth-v1.10.18
 
       - py37-install-geth-v1.10.19
       - py38-install-geth-v1.10.19
       - py39-install-geth-v1.10.19
       - py310-install-geth-v1.10.19
+      - py311-install-geth-v1.10.19
 
       - py37-install-geth-v1.10.20
       - py38-install-geth-v1.10.20
       - py39-install-geth-v1.10.20
       - py310-install-geth-v1.10.20
+      - py311-install-geth-v1.10.20
 
       - py37-install-geth-v1.10.21
       - py38-install-geth-v1.10.21
       - py39-install-geth-v1.10.21
       - py310-install-geth-v1.10.21
+      - py311-install-geth-v1.10.21
 
       - py37-install-geth-v1.10.22
       - py38-install-geth-v1.10.22
       - py39-install-geth-v1.10.22
       - py310-install-geth-v1.10.22
+      - py311-install-geth-v1.10.22
 
       - py37-install-geth-v1.10.23
       - py38-install-geth-v1.10.23
       - py39-install-geth-v1.10.23
       - py310-install-geth-v1.10.23
+      - py311-install-geth-v1.10.23
 
       - py37-install-geth-v1.10.24
       - py38-install-geth-v1.10.24
       - py39-install-geth-v1.10.24
       - py310-install-geth-v1.10.24
+      - py311-install-geth-v1.10.24
 
       - py37-install-geth-v1.10.25
       - py38-install-geth-v1.10.25
       - py39-install-geth-v1.10.25
       - py310-install-geth-v1.10.25
+      - py311-install-geth-v1.10.25
 
       - py37-install-geth-v1.10.26
       - py38-install-geth-v1.10.26
       - py39-install-geth-v1.10.26
       - py310-install-geth-v1.10.26
+      - py311-install-geth-v1.10.26
 
       - py37-install-geth-v1.11.0
       - py38-install-geth-v1.11.0
       - py39-install-geth-v1.11.0
       - py310-install-geth-v1.11.0
+      - py311-install-geth-v1.11.0
 
       - py37-install-geth-v1.11.1
       - py38-install-geth-v1.11.1
       - py39-install-geth-v1.11.1
       - py310-install-geth-v1.11.1
+      - py311-install-geth-v1.11.1
 
       - py37-install-geth-v1.11.2
       - py38-install-geth-v1.11.2
       - py39-install-geth-v1.11.2
       - py310-install-geth-v1.11.2
+      - py311-install-geth-v1.11.2
 
       - py37-lint
       - py38-lint
       - py39-lint
       - py310-lint
+      - py311-lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.0
 # heavily inspired by:
 # https://raw.githubusercontent.com/pinax/pinax-wiki/6bd2a99ab6f702e300d708532a6d1d9aa638b9f8/.circleci/config.yml
 
-common_go_v_1_19_3: &common_go_v_1_19_3
+common_go_v_1_20_1: &common_go_v_1_20_1
   working_directory: ~/repo
   steps:
     - checkout
@@ -33,8 +33,8 @@ common_go_v_1_19_3: &common_go_v_1_19_3
           pip install --user tox
           pip install --user checksumdir
     - run:
-        name: install golang-1.19.3
-        command: ./.circleci/install_golang.sh 1.19.3
+        name: install golang-1.20.1
+        command: ./.circleci/install_golang.sh 1.20.1
     - run:
         name: run tox
         command: python -m tox
@@ -53,840 +53,840 @@ common_go_v_1_19_3: &common_go_v_1_19_3
 
 jobs:
   py37-install-geth-v1.10.0:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.7
         environment:
           GETH_VERSION: v1.10.0
           TOXENV: py37-install-geth-v1.10.0
   py38-install-geth-v1.10.0:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.8
         environment:
           GETH_VERSION: v1.10.0
           TOXENV: py38-install-geth-v1.10.0
   py39-install-geth-v1.10.0:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.9
         environment:
           GETH_VERSION: v1.10.0
           TOXENV: py39-install-geth-v1.10.0
   py310-install-geth-v1.10.0:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.10
         environment:
           GETH_VERSION: v1.10.0
           TOXENV: py310-install-geth-v1.10.0
   py37-install-geth-v1.10.1:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.7
         environment:
           GETH_VERSION: v1.10.1
           TOXENV: py37-install-geth-v1.10.1
   py38-install-geth-v1.10.1:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.8
         environment:
           GETH_VERSION: v1.10.1
           TOXENV: py38-install-geth-v1.10.1
   py39-install-geth-v1.10.1:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.9
         environment:
           GETH_VERSION: v1.10.1
           TOXENV: py39-install-geth-v1.10.1
   py310-install-geth-v1.10.1:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.10
         environment:
           GETH_VERSION: v1.10.1
           TOXENV: py310-install-geth-v1.10.1
   py37-install-geth-v1.10.2:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.7
         environment:
           GETH_VERSION: v1.10.2
           TOXENV: py37-install-geth-v1.10.2
   py38-install-geth-v1.10.2:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.8
         environment:
           GETH_VERSION: v1.10.2
           TOXENV: py38-install-geth-v1.10.2
   py39-install-geth-v1.10.2:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.9
         environment:
           GETH_VERSION: v1.10.2
           TOXENV: py39-install-geth-v1.10.2
   py310-install-geth-v1.10.2:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.10
         environment:
           GETH_VERSION: v1.10.2
           TOXENV: py310-install-geth-v1.10.2
   py37-install-geth-v1.10.3:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.7
         environment:
           GETH_VERSION: v1.10.3
           TOXENV: py37-install-geth-v1.10.3
   py38-install-geth-v1.10.3:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.8
         environment:
           GETH_VERSION: v1.10.3
           TOXENV: py38-install-geth-v1.10.3
   py39-install-geth-v1.10.3:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.9
         environment:
           GETH_VERSION: v1.10.3
           TOXENV: py39-install-geth-v1.10.3
   py310-install-geth-v1.10.3:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.10
         environment:
           GETH_VERSION: v1.10.3
           TOXENV: py310-install-geth-v1.10.3
   py37-install-geth-v1.10.4:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.7
         environment:
           GETH_VERSION: v1.10.4
           TOXENV: py37-install-geth-v1.10.4
   py38-install-geth-v1.10.4:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.8
         environment:
           GETH_VERSION: v1.10.4
           TOXENV: py38-install-geth-v1.10.4
   py39-install-geth-v1.10.4:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.9
         environment:
           GETH_VERSION: v1.10.4
           TOXENV: py39-install-geth-v1.10.4
   py310-install-geth-v1.10.4:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.10
         environment:
           GETH_VERSION: v1.10.4
           TOXENV: py310-install-geth-v1.10.4
   py37-install-geth-v1.10.5:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.7
         environment:
           GETH_VERSION: v1.10.5
           TOXENV: py37-install-geth-v1.10.5
   py38-install-geth-v1.10.5:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.8
         environment:
           GETH_VERSION: v1.10.5
           TOXENV: py38-install-geth-v1.10.5
   py39-install-geth-v1.10.5:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.9
         environment:
           GETH_VERSION: v1.10.5
           TOXENV: py39-install-geth-v1.10.5
   py310-install-geth-v1.10.5:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.10
         environment:
           GETH_VERSION: v1.10.5
           TOXENV: py310-install-geth-v1.10.5
   py37-install-geth-v1.10.6:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.7
         environment:
           GETH_VERSION: v1.10.6
           TOXENV: py37-install-geth-v1.10.6
   py38-install-geth-v1.10.6:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.8
         environment:
           GETH_VERSION: v1.10.6
           TOXENV: py38-install-geth-v1.10.6
   py39-install-geth-v1.10.6:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.9
         environment:
           GETH_VERSION: v1.10.6
           TOXENV: py39-install-geth-v1.10.6
   py310-install-geth-v1.10.6:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.10
         environment:
           GETH_VERSION: v1.10.6
           TOXENV: py310-install-geth-v1.10.6
   py37-install-geth-v1.10.7:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.7
         environment:
           GETH_VERSION: v1.10.7
           TOXENV: py37-install-geth-v1.10.7
   py38-install-geth-v1.10.7:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.8
         environment:
           GETH_VERSION: v1.10.7
           TOXENV: py38-install-geth-v1.10.7
   py39-install-geth-v1.10.7:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.9
         environment:
           GETH_VERSION: v1.10.7
           TOXENV: py39-install-geth-v1.10.7
   py310-install-geth-v1.10.7:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.10
         environment:
           GETH_VERSION: v1.10.7
           TOXENV: py310-install-geth-v1.10.7
   py37-install-geth-v1.10.8:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.7
         environment:
           GETH_VERSION: v1.10.8
           TOXENV: py37-install-geth-v1.10.8
   py38-install-geth-v1.10.8:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.8
         environment:
           GETH_VERSION: v1.10.8
           TOXENV: py38-install-geth-v1.10.8
   py39-install-geth-v1.10.8:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.9
         environment:
           GETH_VERSION: v1.10.8
           TOXENV: py39-install-geth-v1.10.8
   py310-install-geth-v1.10.8:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.10
         environment:
           GETH_VERSION: v1.10.8
           TOXENV: py310-install-geth-v1.10.8
   py37-install-geth-v1.10.9:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.7
         environment:
           GETH_VERSION: v1.10.9
           TOXENV: py37-install-geth-v1.10.9
   py38-install-geth-v1.10.9:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.8
         environment:
           GETH_VERSION: v1.10.9
           TOXENV: py38-install-geth-v1.10.9
   py39-install-geth-v1.10.9:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.9
         environment:
           GETH_VERSION: v1.10.9
           TOXENV: py39-install-geth-v1.10.9
   py310-install-geth-v1.10.9:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.10
         environment:
           GETH_VERSION: v1.10.9
           TOXENV: py310-install-geth-v1.10.9
   py37-install-geth-v1.10.10:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.7
         environment:
           GETH_VERSION: v1.10.10
           TOXENV: py37-install-geth-v1.10.10
   py38-install-geth-v1.10.10:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.8
         environment:
           GETH_VERSION: v1.10.10
           TOXENV: py38-install-geth-v1.10.10
   py39-install-geth-v1.10.10:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.9
         environment:
           GETH_VERSION: v1.10.10
           TOXENV: py39-install-geth-v1.10.10
   py310-install-geth-v1.10.10:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.10
         environment:
           GETH_VERSION: v1.10.10
           TOXENV: py310-install-geth-v1.10.10
   py37-install-geth-v1.10.11:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.7
         environment:
           GETH_VERSION: v1.10.11
           TOXENV: py37-install-geth-v1.10.11
   py38-install-geth-v1.10.11:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.8
         environment:
           GETH_VERSION: v1.10.11
           TOXENV: py38-install-geth-v1.10.11
   py39-install-geth-v1.10.11:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.9
         environment:
           GETH_VERSION: v1.10.11
           TOXENV: py39-install-geth-v1.10.11
   py310-install-geth-v1.10.11:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.10
         environment:
           GETH_VERSION: v1.10.11
           TOXENV: py310-install-geth-v1.10.11
   py37-install-geth-v1.10.12:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.7
         environment:
           GETH_VERSION: v1.10.12
           TOXENV: py37-install-geth-v1.10.12
   py38-install-geth-v1.10.12:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.8
         environment:
           GETH_VERSION: v1.10.12
           TOXENV: py38-install-geth-v1.10.12
   py39-install-geth-v1.10.12:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.9
         environment:
           GETH_VERSION: v1.10.12
           TOXENV: py39-install-geth-v1.10.12
   py310-install-geth-v1.10.12:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.10
         environment:
           GETH_VERSION: v1.10.12
           TOXENV: py310-install-geth-v1.10.12
   py37-install-geth-v1.10.13:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.7
         environment:
           GETH_VERSION: v1.10.13
           TOXENV: py37-install-geth-v1.10.13
   py38-install-geth-v1.10.13:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.8
         environment:
           GETH_VERSION: v1.10.13
           TOXENV: py38-install-geth-v1.10.13
   py39-install-geth-v1.10.13:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.9
         environment:
           GETH_VERSION: v1.10.13
           TOXENV: py39-install-geth-v1.10.13
   py310-install-geth-v1.10.13:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.10
         environment:
           GETH_VERSION: v1.10.13
           TOXENV: py310-install-geth-v1.10.13
   py37-install-geth-v1.10.14:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.7
         environment:
           GETH_VERSION: v1.10.14
           TOXENV: py37-install-geth-v1.10.14
   py38-install-geth-v1.10.14:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.8
         environment:
           GETH_VERSION: v1.10.14
           TOXENV: py38-install-geth-v1.10.14
   py39-install-geth-v1.10.14:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.9
         environment:
           GETH_VERSION: v1.10.14
           TOXENV: py39-install-geth-v1.10.14
   py310-install-geth-v1.10.14:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.10
         environment:
           GETH_VERSION: v1.10.14
           TOXENV: py310-install-geth-v1.10.14
   py37-install-geth-v1.10.15:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.7
         environment:
           GETH_VERSION: v1.10.15
           TOXENV: py37-install-geth-v1.10.15
   py38-install-geth-v1.10.15:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.8
         environment:
           GETH_VERSION: v1.10.15
           TOXENV: py38-install-geth-v1.10.15
   py39-install-geth-v1.10.15:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.9
         environment:
           GETH_VERSION: v1.10.15
           TOXENV: py39-install-geth-v1.10.15
   py310-install-geth-v1.10.15:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.10
         environment:
           GETH_VERSION: v1.10.15
           TOXENV: py310-install-geth-v1.10.15
   py37-install-geth-v1.10.16:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.7
         environment:
           GETH_VERSION: v1.10.16
           TOXENV: py37-install-geth-v1.10.16
   py38-install-geth-v1.10.16:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.8
         environment:
           GETH_VERSION: v1.10.16
           TOXENV: py38-install-geth-v1.10.16
   py39-install-geth-v1.10.16:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.9
         environment:
           GETH_VERSION: v1.10.16
           TOXENV: py39-install-geth-v1.10.16
   py310-install-geth-v1.10.16:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.10
         environment:
           GETH_VERSION: v1.10.16
           TOXENV: py310-install-geth-v1.10.16
   py37-install-geth-v1.10.17:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.7
         environment:
           GETH_VERSION: v1.10.17
           TOXENV: py37-install-geth-v1.10.17
   py38-install-geth-v1.10.17:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.8
         environment:
           GETH_VERSION: v1.10.17
           TOXENV: py38-install-geth-v1.10.17
   py39-install-geth-v1.10.17:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.9
         environment:
           GETH_VERSION: v1.10.17
           TOXENV: py39-install-geth-v1.10.17
   py310-install-geth-v1.10.17:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.10
         environment:
           GETH_VERSION: v1.10.17
           TOXENV: py310-install-geth-v1.10.17
   py37-install-geth-v1.10.18:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.7
         environment:
           GETH_VERSION: v1.10.18
           TOXENV: py37-install-geth-v1.10.18
   py38-install-geth-v1.10.18:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.8
         environment:
           GETH_VERSION: v1.10.18
           TOXENV: py38-install-geth-v1.10.18
   py39-install-geth-v1.10.18:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.9
         environment:
           GETH_VERSION: v1.10.18
           TOXENV: py39-install-geth-v1.10.18
   py310-install-geth-v1.10.18:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.10
         environment:
           GETH_VERSION: v1.10.18
           TOXENV: py310-install-geth-v1.10.18
   py37-install-geth-v1.10.19:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.7
         environment:
           GETH_VERSION: v1.10.19
           TOXENV: py37-install-geth-v1.10.19
   py38-install-geth-v1.10.19:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.8
         environment:
           GETH_VERSION: v1.10.19
           TOXENV: py38-install-geth-v1.10.19
   py39-install-geth-v1.10.19:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.9
         environment:
           GETH_VERSION: v1.10.19
           TOXENV: py39-install-geth-v1.10.19
   py310-install-geth-v1.10.19:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.10
         environment:
           GETH_VERSION: v1.10.19
           TOXENV: py310-install-geth-v1.10.19
   py37-install-geth-v1.10.20:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.7
         environment:
           GETH_VERSION: v1.10.20
           TOXENV: py37-install-geth-v1.10.20
   py38-install-geth-v1.10.20:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.8
         environment:
           GETH_VERSION: v1.10.20
           TOXENV: py38-install-geth-v1.10.20
   py39-install-geth-v1.10.20:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.9
         environment:
           GETH_VERSION: v1.10.20
           TOXENV: py39-install-geth-v1.10.20
   py310-install-geth-v1.10.20:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.10
         environment:
           GETH_VERSION: v1.10.20
           TOXENV: py310-install-geth-v1.10.20
   py37-install-geth-v1.10.21:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.7
         environment:
           GETH_VERSION: v1.10.21
           TOXENV: py37-install-geth-v1.10.21
   py38-install-geth-v1.10.21:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.8
         environment:
           GETH_VERSION: v1.10.21
           TOXENV: py38-install-geth-v1.10.21
   py39-install-geth-v1.10.21:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.9
         environment:
           GETH_VERSION: v1.10.21
           TOXENV: py39-install-geth-v1.10.21
   py310-install-geth-v1.10.21:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.10
         environment:
           GETH_VERSION: v1.10.21
           TOXENV: py310-install-geth-v1.10.21
   py37-install-geth-v1.10.22:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.7
         environment:
           GETH_VERSION: v1.10.22
           TOXENV: py37-install-geth-v1.10.22
   py38-install-geth-v1.10.22:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.8
         environment:
           GETH_VERSION: v1.10.22
           TOXENV: py38-install-geth-v1.10.22
   py39-install-geth-v1.10.22:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.9
         environment:
           GETH_VERSION: v1.10.22
           TOXENV: py39-install-geth-v1.10.22
   py310-install-geth-v1.10.22:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.10
         environment:
           GETH_VERSION: v1.10.22
           TOXENV: py310-install-geth-v1.10.22
   py37-install-geth-v1.10.23:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.7
         environment:
           GETH_VERSION: v1.10.23
           TOXENV: py37-install-geth-v1.10.23
   py38-install-geth-v1.10.23:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.8
         environment:
           GETH_VERSION: v1.10.23
           TOXENV: py38-install-geth-v1.10.23
   py39-install-geth-v1.10.23:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.9
         environment:
           GETH_VERSION: v1.10.23
           TOXENV: py39-install-geth-v1.10.23
   py310-install-geth-v1.10.23:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.10
         environment:
           GETH_VERSION: v1.10.23
           TOXENV: py310-install-geth-v1.10.23
   py37-install-geth-v1.10.24:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.7
         environment:
           GETH_VERSION: v1.10.24
           TOXENV: py37-install-geth-v1.10.24
   py38-install-geth-v1.10.24:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.8
         environment:
           GETH_VERSION: v1.10.24
           TOXENV: py38-install-geth-v1.10.24
   py39-install-geth-v1.10.24:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.9
         environment:
           GETH_VERSION: v1.10.24
           TOXENV: py39-install-geth-v1.10.24
   py310-install-geth-v1.10.24:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.10
         environment:
           GETH_VERSION: v1.10.24
           TOXENV: py310-install-geth-v1.10.24
   py37-install-geth-v1.10.25:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.7
         environment:
           GETH_VERSION: v1.10.25
           TOXENV: py37-install-geth-v1.10.25
   py38-install-geth-v1.10.25:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.8
         environment:
           GETH_VERSION: v1.10.25
           TOXENV: py38-install-geth-v1.10.25
   py39-install-geth-v1.10.25:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.9
         environment:
           GETH_VERSION: v1.10.25
           TOXENV: py39-install-geth-v1.10.25
   py310-install-geth-v1.10.25:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.10
         environment:
           GETH_VERSION: v1.10.25
           TOXENV: py310-install-geth-v1.10.25
   py37-install-geth-v1.10.26:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.7
         environment:
           GETH_VERSION: v1.10.26
           TOXENV: py37-install-geth-v1.10.26
   py38-install-geth-v1.10.26:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.8
         environment:
           GETH_VERSION: v1.10.26
           TOXENV: py38-install-geth-v1.10.26
   py39-install-geth-v1.10.26:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.9
         environment:
           GETH_VERSION: v1.10.26
           TOXENV: py39-install-geth-v1.10.26
   py310-install-geth-v1.10.26:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.10
         environment:
           GETH_VERSION: v1.10.26
           TOXENV: py310-install-geth-v1.10.26
   py37-install-geth-v1.11.0:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.7
         environment:
           GETH_VERSION: v1.11.0
           TOXENV: py37-install-geth-v1.11.0
   py38-install-geth-v1.11.0:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.8
         environment:
           GETH_VERSION: v1.11.0
           TOXENV: py38-install-geth-v1.11.0
   py39-install-geth-v1.11.0:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.9
         environment:
           GETH_VERSION: v1.11.0
           TOXENV: py39-install-geth-v1.11.0
   py310-install-geth-v1.11.0:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.10
         environment:
           GETH_VERSION: v1.11.0
           TOXENV: py310-install-geth-v1.11.0
   py37-install-geth-v1.11.1:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.7
         environment:
           GETH_VERSION: v1.11.1
           TOXENV: py37-install-geth-v1.11.1
   py38-install-geth-v1.11.1:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.8
         environment:
           GETH_VERSION: v1.11.1
           TOXENV: py38-install-geth-v1.11.1
   py39-install-geth-v1.11.1:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.9
         environment:
           GETH_VERSION: v1.11.1
           TOXENV: py39-install-geth-v1.11.1
   py310-install-geth-v1.11.1:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.10
         environment:
           GETH_VERSION: v1.11.1
           TOXENV: py310-install-geth-v1.11.1
   py37-install-geth-v1.11.2:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.7
         environment:
           GETH_VERSION: v1.11.2
           TOXENV: py37-install-geth-v1.11.2
   py38-install-geth-v1.11.2:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.8
         environment:
           GETH_VERSION: v1.11.2
           TOXENV: py38-install-geth-v1.11.2
   py39-install-geth-v1.11.2:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.9
         environment:
           GETH_VERSION: v1.11.2
           TOXENV: py39-install-geth-v1.11.2
   py310-install-geth-v1.11.2:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.10
         environment:
@@ -894,25 +894,25 @@ jobs:
           TOXENV: py310-install-geth-v1.11.2
 
   py37-lint:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.7
         environment:
           TOXENV: py37-lint
   py38-lint:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.8
         environment:
           TOXENV: py38-lint
   py39-lint:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.9
         environment:
           TOXENV: py39-lint
   py310-lint:
-    <<: *common_go_v_1_19_3
+    <<: *common_go_v_1_20_1
     docker:
       - image: cimg/python:3.10
         environment:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,13 +1,11 @@
 Unreleased
 -----
-
- - Add support for geth `1.11.2`
- - Add support for geth `1.11.0` and `1.11.1`
- - Add support for geth `1.10.26`
+ - Upgrade circleci golang version to `1.20.1`
+ - Add support for python `3.11`
+ - Add support for geth `1.10.26`, `1.11.0`, `1.11.1`, and `1.11.2`
  - Fix incorrect comment in `install_geth.sh`
  - Add `clique` to `ALL_APIS`
  - Add `gcmode` option to Geth process wrapper
- - Use latest go version `1.19.3` for Circle CI jobs
 
 3.10.0
 ------

--- a/setup.py
+++ b/setup.py
@@ -67,5 +67,6 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{37,38,39,310}-lint
-    py{37,38,39,310}-install-geth-{ \
+    py{37,38,39,310,311}-lint
+    py{37,38,39,310,311}-install-geth-{ \
         v1.9.14, v1.9.15, v1.9.16, v1.9.17, v1.9.18, v1.9.19, v1.9.20, \
         v1.9.21, v1.9.22, v1.9.23, v1.9.24, v1.9.25, v1.10.0, v1.10.1, \
         v1.10.2, v1.10.3, v1.10.4, v1.10.5, v1.10.6, v1.10.7, v1.10.8, \
@@ -38,6 +38,7 @@ basepython =
     py38: python3.8
     py39: python3.9
     py310: python3.10
+    py311: python3.11
 
 
 [common_geth_installation_and_check]
@@ -48,28 +49,8 @@ commands =
     pytest {posargs:-s tests/installation}
 
 
-[common-lint]
+[testenv:py{37,38,39,310,311}-lint]
 deps = .[lint]
 setenv = MYPYPATH={toxinidir}:{toxinidir}/stubs
 commands =
     flake8 {toxinidir}/geth
-
-[testenv:py37-lint]
-deps = {[common-lint]deps}
-setenv = {[common-lint]setenv}
-commands = {[common-lint]commands}
-
-[testenv:py38-lint]
-deps = {[common-lint]deps}
-setenv = {[common-lint]setenv}
-commands = {[common-lint]commands}
-
-[testenv:py39-lint]
-deps = {[common-lint]deps}
-setenv = {[common-lint]setenv}
-commands = {[common-lint]commands}
-
-[testenv:py310-lint]
-deps = {[common-lint]deps}
-setenv = {[common-lint]setenv}
-commands = {[common-lint]commands}


### PR DESCRIPTION
### What was wrong?

- `go` version could use an update. Updated to the latest, `1.20.1`.
- Add support for python `3.11`

#### Cute Animal Picture
```
    .. 
\    o>
/\''/\
```