### PR TITLE
feat: support miner etherbase

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ Unreleased
 ------
 
 - Add support for geth `1.11.3`, `1.11.4`, and `1.11.5`
+- Add `miner_etherbase` to supported geth kwargs
 
 3.11.0
 ------

--- a/geth/wrapper.py
+++ b/geth/wrapper.py
@@ -121,6 +121,7 @@ def construct_popen_command(data_dir=None,
                             mine=False,
                             autodag=False,
                             miner_threads=None,
+                            miner_etherbase=None,
                             nice=True,
                             unlock=None,
                             password=None,
@@ -242,6 +243,11 @@ def construct_popen_command(data_dir=None,
         if not mine:
             raise ValueError("`mine` must be truthy when specifying `miner_threads`")
         builder.extend(('--miner.threads', miner_threads))
+
+    if miner_etherbase is not None:
+        if not mine:
+            raise ValueError('`mine` must be truthy when specifying `miner_etherbase`')
+        builder.extend(('--miner.etherbase', miner_etherbase))
 
     if autodag:
         builder.append('--autodag')


### PR DESCRIPTION
### What was wrong?

This is needed to support Geth 1.11.1 and above.
`--miner.etherbase` is now a required flag when using `--mine`.

### How was it fixed?

Add support for the flag.
I made sure it works in Ape!

#### Cute Animal Picture

![](https://www.pbs.org/wnet/nature/files/2021/09/david-clode-0zTNbKfy4tw-unsplash-scaled-e1630589939702.jpg)
