### PR TITLE
feat: allow setting out files

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+Unreleased
+----------
+
+- Allow initializing `BaseGethProcess` with `stdin`, `stdout`, and `stderr`
+
 3.12.0
 ------
 

--- a/geth/process.py
+++ b/geth/process.py
@@ -54,9 +54,16 @@ logger = logging.getLogger(__name__)
 class BaseGethProcess(object):
     _proc = None
 
-    def __init__(self, geth_kwargs):
+    def __init__(self,
+                 geth_kwargs,
+                 stdin=subprocess.PIPE,
+                 stdout=subprocess.PIPE,
+                 stderr=subprocess.PIPE):
         self.geth_kwargs = geth_kwargs
         self.command = construct_popen_command(**geth_kwargs)
+        self.stdin = stdin
+        self.stdout = stdout
+        self.stderr = stderr
 
     is_running = False
 
@@ -68,9 +75,9 @@ class BaseGethProcess(object):
         logger.info("Launching geth: %s", " ".join(self.command))
         self.proc = subprocess.Popen(
             self.command,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stdin=self.stdin,
+            stdout=self.stdout,
+            stderr=self.stderr,
         )
 
     def __enter__(self):


### PR DESCRIPTION
### What was wrong?

In Ape, we like to set these to DEVNULL for less verbose loglevels because it helps quiet noisy pytest caplogs.

### How was it fixed?

parametrize in ctor

#### Cute Animal Picture

> put a cute animal picture here.
