### PR TITLE
Remove `miner.threads` default set

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Unreleased
 ----------
 
+- Remove `miner.thread` default since no longer supported
 - Update ``tox`` and the way it is installed for CircleCI runs
 - Add support for geth ``1.11.6``
 - Allow initializing `BaseGethProcess` with `stdin`, `stdout`, and `stderr`

--- a/geth/wrapper.py
+++ b/geth/wrapper.py
@@ -47,7 +47,6 @@ def construct_test_chain_kwargs(**overrides):
     overrides.setdefault('unlock', '0')
     overrides.setdefault('password', DEFAULT_PASSWORD_PATH)
     overrides.setdefault('mine', True)
-    overrides.setdefault('miner_threads', '1')
     overrides.setdefault('no_discover', True)
     overrides.setdefault('max_peers', '0')
     overrides.setdefault('network_id', '1234')


### PR DESCRIPTION
### What was wrong?

As of the lastest geth release, it seems like this is no longer an option.
I can't find any changelog entry mentioning its removal though
Removig this line causes things to work again for me.

### How was it fixed?

Remove setting the default for miner threads.
Is there something else that should be done? :eye:

#### Cute Animal Picture
<img width="511" alt="Screenshot 2023-05-26 at 11 37 44" src="https://github.com/ethereum/py-geth/assets/19540978/9d912540-4d0f-4887-a65c-354109ce38a1">

