### PR TITLE
Configure geth for clique consensus

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Python wrapper around running `geth` as a subprocess
 
 This library requires the `geth` executable to be present.
 
+> If managing your own bundled version of geth, set the path to the binary using the `GETH_BINARY` environment variable.
+
 ## Installation
 
 Installation

--- a/geth/chain.py
+++ b/geth/chain.py
@@ -94,7 +94,7 @@ def write_genesis_file(
     nonce="0xdeadbeefdeadbeef",
     timestamp="0x0",
     parentHash="0x0000000000000000000000000000000000000000000000000000000000000000",
-    extraData="0x686f727365",
+    extraData=None,
     gasLimit="0x47d5cc",
     difficulty="0x01",
     mixhash="0x0000000000000000000000000000000000000000000000000000000000000000",
@@ -124,7 +124,14 @@ def write_genesis_file(
             "londonBlock": 0,
             "daoForkBlock": 0,
             "daoForSupport": True,
+            # Using the Ethash consensus algorithm is deprecated
+            # Instead, use the Clique consensus algorithm
+            # https://geth.ethereum.org/docs/interface/private-network
+            "clique": {"period": 5, "epoch": 30000},
         }
+
+    # Assign a signer (coinbase) to the genesis block for Clique
+    extraData = bytes("0x" + "0" * 64 + coinbase[2:] + "0" * 130, "ascii")
 
     genesis_data = {
         "nonce": nonce,

--- a/geth/wrapper.py
+++ b/geth/wrapper.py
@@ -254,11 +254,11 @@ def construct_popen_command(
         builder.append("--mine")
 
     if miner_threads is not None:
-        if not mine:
-            raise ValueError("`mine` must be truthy when specifying `miner_threads`")
         logging.warning(
             "`--miner.threads` is deprecated and will be removed in a future release."
         )
+        if not mine:
+            raise ValueError("`mine` must be truthy when specifying `miner_threads`")
         builder.extend(("--miner.threads", miner_threads))
 
     if miner_etherbase is not None:

--- a/geth/wrapper.py
+++ b/geth/wrapper.py
@@ -151,6 +151,12 @@ def construct_popen_command(
     if geth_executable is None:
         geth_executable = get_geth_binary_path()
 
+    if not is_executable_available(geth_executable):
+        raise ValueError(
+            "No geth executable found.  Please ensure geth is installed and "
+            "available on your PATH or use the GETH_BINARY environment variable"
+        )
+
     if ipc_api is not None:
         raise DeprecationWarning(
             "The ipc_api flag has been deprecated.  The ipc API is now on by "

--- a/geth/wrapper.py
+++ b/geth/wrapper.py
@@ -1,4 +1,5 @@
 import functools
+import logging
 import os
 import subprocess
 import sys
@@ -117,7 +118,7 @@ def construct_popen_command(
     no_discover=None,
     mine=False,
     autodag=False,
-    miner_threads=None,
+    miner_threads=None,  # deprecated
     miner_etherbase=None,
     nice=True,
     unlock=None,
@@ -255,6 +256,9 @@ def construct_popen_command(
     if miner_threads is not None:
         if not mine:
             raise ValueError("`mine` must be truthy when specifying `miner_threads`")
+        logging.warning(
+            "`--miner.threads` is deprecated and will be removed in a future release."
+        )
         builder.extend(("--miner.threads", miner_threads))
 
     if miner_etherbase is not None:

--- a/newsfragments/152.misc.rst
+++ b/newsfragments/152.misc.rst
@@ -1,1 +1,1 @@
-Fail fast if ``geth`` is unavailable.
+Fix tests when runnning recent versions of ``geth``. Fail fast if ``geth`` is unavailable.

--- a/newsfragments/152.misc.rst
+++ b/newsfragments/152.misc.rst
@@ -1,0 +1,1 @@
+Fail fast if ``geth`` is unavailable.


### PR DESCRIPTION
### What was wrong?

Recent geth versions (>1.12.0) switched to PoS. The `ethash` consensus algorithm is used by deafult (for now) and has been deprecated. Because of this the network cannot run. As an alternative, `clique` is offered as a PoA. For more info, check out https://geth.ethereum.org/docs/fundamentals/private-network#clique.

Also suffered from a 'File not found' error but prescribed the `GETH_BINARY` env var to specify the path to `geth`.

### How was it fixed?

Check that the executable is available and throw an error if not.
Added words to the README for rolling your own geth path.

### Todo:
- [X] Clean up commit history

- [X] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/py-geth/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://w0.peakpx.com/wallpaper/36/830/HD-wallpaper-wolf-puppies-cute-baby-wolves.jpg)