### PR TITLE
changelog moved to an rst file, failed to update in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ log_date_format = "%m-%d %H:%M:%S"
 [tool.towncrier]
 # Read https://github.com/ethereum/py-geth/blob/master/newsfragments/README.md for instructions
 package = "geth"
-filename = "CHANGELOG"
+filename = "CHANGELOG.rst"
 directory = "newsfragments"
 underlines = ["-", "~", "^"]
 title_format = "py-geth v{version} ({project_date})"


### PR DESCRIPTION
### What was wrong?

Previous PR failed to update CHANGELOG to have an rst extension 

### How was it fixed?

file is now `CHANGELOG.rst`

#### Cute Animal Picture

![image](https://github.com/ethereum/py-geth/assets/5199899/91bd7746-bd88-446f-bd0f-71228ab12730)
