### PR TITLE
fix: issue where extraData arg was ignored in chain genesis functions

### DIFF
--- a/geth/chain.py
+++ b/geth/chain.py
@@ -131,7 +131,11 @@ def write_genesis_file(
         }
 
     # Assign a signer (coinbase) to the genesis block for Clique
-    extraData = bytes("0x" + "0" * 64 + coinbase[2:] + "0" * 130, "ascii")
+    extraData = (
+        bytes("0x" + "0" * 64 + coinbase[2:] + "0" * 130, "ascii")
+        if extraData is None
+        else extraData
+    )
 
     genesis_data = {
         "nonce": nonce,

--- a/newsfragments/167.bugfix.rst
+++ b/newsfragments/167.bugfix.rst
@@ -1,0 +1,1 @@
+Fix issue where could not set custom extraData in chain genesis


### PR DESCRIPTION
### What was wrong?

Closes #167 

### How was it fixed?

only if calc if not None

question: advice on adding a test?

### Todo:

- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/py-geth/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<>)
