### PR TITLE
Template updates, add py312

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,6 @@ common_go_v1_21_3: &common_go_v1_21_3
         name: install golang-1.21.3
         command: ./.circleci/install_golang.sh 1.21.3
     - run:
-        name: install pre-commit
-        command: python -m pip install --progress-bar=off pre-commit
-    - run:
         name: run tox
         command: python -m tox run -r
     - save_cache:
@@ -51,28 +48,61 @@ common_go_v1_21_3: &common_go_v1_21_3
 orbs:
   win: circleci/windows@5.0.0
 
-windows_steps: &windows_steps
-  executor:
-    name: win/default
-    shell: bash.exe
-  working_directory: C:\Users\circleci\project\py-geth
+windows-wheel-steps:
+  windows-wheel-setup: &windows-wheel-setup
+    executor:
+      name: win/default
+      shell: bash.exe
+    working_directory: C:\Users\circleci\project\py-geth
+    environment:
+      TOXENV: windows-wheel
+  restore-cache-step: &restore-cache-step
+    restore_cache:
+      keys:
+        - cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+  install-pyenv-step: &install-pyenv-step
+    run:
+      name: install pyenv
+      command: |
+        pip install pyenv-win --target $HOME/.pyenv
+        echo 'export PYENV="$HOME/.pyenv/pyenv-win/"' >> $BASH_ENV
+        echo 'export PYENV_ROOT="$HOME/.pyenv/pyenv-win/"' >> $BASH_ENV
+        echo 'export PYENV_USERPROFILE="$HOME/.pyenv/pyenv-win/"' >> $BASH_ENV
+        echo 'export PATH="$PATH:$HOME/.pyenv/pyenv-win/bin"' >> $BASH_ENV
+        echo 'export PATH="$PATH:$HOME/.pyenv/pyenv-win/shims"' >> $BASH_ENV
+        source $BASH_ENV
+        pyenv update
+  install-latest-python-step: &install-latest-python-step
+    run:
+      name: install latest python version and tox
+      command: |
+        LATEST_VERSION=$(pyenv install --list | grep -E "${MINOR_VERSION}\.[0-9]+$" | tail -1)
+        echo "installing python version $LATEST_VERSION"
+        pyenv install $LATEST_VERSION
+        pyenv global $LATEST_VERSION
+        python3 -m pip install --upgrade pip
+        python3 -m pip install tox
+  run-tox-step: &run-tox-step
+    run:
+      name: run tox
+      command: |
+        echo 'running tox with' $(python3 --version)
+        python3 -m tox run -r
+  save-cache-step: &save-cache-step
+    save_cache:
+      paths:
+        - .tox
+      key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+
+docs: &docs
+  docker:
+    - image: common
   steps:
-    - checkout
-    - restore_cache:
-        keys:
-          - cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
     - run:
-        name: install dependencies
+        name: install latexpdf dependencies
         command: |
-          python -m pip install --upgrade pip
-          python -m pip install tox
-    - run:
-        name: run tox
-        command: python -m tox run -r
-    - save_cache:
-        paths:
-          - .tox
-        key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+          sudo apt-get update
+          sudo apt-get install latexmk tex-gyre texlive-fonts-extra
 
 jobs:
   py38-install-geth-v1_11_0:
@@ -103,6 +133,13 @@ jobs:
         environment:
           GETH_VERSION: v1.11.0
           TOXENV: py311-install-geth-v1_11_0
+  py312-install-geth-v1_11_0:
+    <<: *common_go_v1_21_3
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          GETH_VERSION: v1.11.0
+          TOXENV: py312-install-geth-v1_11_0
   py38-install-geth-v1_11_1:
     <<: *common_go_v1_21_3
     docker:
@@ -131,6 +168,13 @@ jobs:
         environment:
           GETH_VERSION: v1.11.1
           TOXENV: py311-install-geth-v1_11_1
+  py312-install-geth-v1_11_1:
+    <<: *common_go_v1_21_3
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          GETH_VERSION: v1.11.1
+          TOXENV: py312-install-geth-v1_11_1
   py38-install-geth-v1_11_2:
     <<: *common_go_v1_21_3
     docker:
@@ -159,6 +203,13 @@ jobs:
         environment:
           GETH_VERSION: v1.11.2
           TOXENV: py311-install-geth-v1_11_2
+  py312-install-geth-v1_11_2:
+    <<: *common_go_v1_21_3
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          GETH_VERSION: v1.11.2
+          TOXENV: py312-install-geth-v1_11_2
   py38-install-geth-v1_11_3:
     <<: *common_go_v1_21_3
     docker:
@@ -187,6 +238,13 @@ jobs:
         environment:
           GETH_VERSION: v1.11.3
           TOXENV: py311-install-geth-v1_11_3
+  py312-install-geth-v1_11_3:
+    <<: *common_go_v1_21_3
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          GETH_VERSION: v1.11.3
+          TOXENV: py312-install-geth-v1_11_3
   py38-install-geth-v1_11_4:
     <<: *common_go_v1_21_3
     docker:
@@ -215,6 +273,13 @@ jobs:
         environment:
           GETH_VERSION: v1.11.4
           TOXENV: py311-install-geth-v1_11_4
+  py312-install-geth-v1_11_4:
+    <<: *common_go_v1_21_3
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          GETH_VERSION: v1.11.4
+          TOXENV: py312-install-geth-v1_11_4
   py38-install-geth-v1_11_5:
     <<: *common_go_v1_21_3
     docker:
@@ -243,6 +308,13 @@ jobs:
         environment:
           GETH_VERSION: v1.11.5
           TOXENV: py311-install-geth-v1_11_5
+  py312-install-geth-v1_11_5:
+    <<: *common_go_v1_21_3
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          GETH_VERSION: v1.11.5
+          TOXENV: py312-install-geth-v1_11_5
   py38-install-geth-v1_11_6:
     <<: *common_go_v1_21_3
     docker:
@@ -271,6 +343,13 @@ jobs:
         environment:
           GETH_VERSION: v1.11.6
           TOXENV: py311-install-geth-v1_11_6
+  py312-install-geth-v1_11_6:
+    <<: *common_go_v1_21_3
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          GETH_VERSION: v1.11.6
+          TOXENV: py312-install-geth-v1_11_6
   py38-install-geth-v1_12_0:
     <<: *common_go_v1_21_3
     docker:
@@ -299,6 +378,13 @@ jobs:
         environment:
           GETH_VERSION: v1.12.0
           TOXENV: py311-install-geth-v1_12_0
+  py312-install-geth-v1_12_0:
+    <<: *common_go_v1_21_3
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          GETH_VERSION: v1.12.0
+          TOXENV: py312-install-geth-v1_12_0
   py38-install-geth-v1_12_1:
     <<: *common_go_v1_21_3
     docker:
@@ -327,6 +413,13 @@ jobs:
         environment:
           GETH_VERSION: v1.12.1
           TOXENV: py311-install-geth-v1_12_1
+  py312-install-geth-v1_12_1:
+    <<: *common_go_v1_21_3
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          GETH_VERSION: v1.12.1
+          TOXENV: py312-install-geth-v1_12_1
   py38-install-geth-v1_12_2:
     <<: *common_go_v1_21_3
     docker:
@@ -355,6 +448,13 @@ jobs:
         environment:
           GETH_VERSION: v1.12.2
           TOXENV: py311-install-geth-v1_12_2
+  py312-install-geth-v1_12_2:
+    <<: *common_go_v1_21_3
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          GETH_VERSION: v1.12.2
+          TOXENV: py312-install-geth-v1_12_2
   py38-install-geth-v1_13_0:
     <<: *common_go_v1_21_3
     docker:
@@ -383,6 +483,13 @@ jobs:
         environment:
           GETH_VERSION: v1.13.0
           TOXENV: py311-install-geth-v1_13_0
+  py312-install-geth-v1_13_0:
+    <<: *common_go_v1_21_3
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          GETH_VERSION: v1.13.0
+          TOXENV: py312-install-geth-v1_13_0
   py38-install-geth-v1_13_1:
     <<: *common_go_v1_21_3
     docker:
@@ -411,6 +518,13 @@ jobs:
         environment:
           GETH_VERSION: v1.13.1
           TOXENV: py311-install-geth-v1_13_1
+  py312-install-geth-v1_13_1:
+    <<: *common_go_v1_21_3
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          GETH_VERSION: v1.13.1
+          TOXENV: py312-install-geth-v1_13_1
   py38-install-geth-v1_13_2:
     <<: *common_go_v1_21_3
     docker:
@@ -439,6 +553,13 @@ jobs:
         environment:
           GETH_VERSION: v1.13.2
           TOXENV: py311-install-geth-v1_13_2
+  py312-install-geth-v1_13_2:
+    <<: *common_go_v1_21_3
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          GETH_VERSION: v1.13.2
+          TOXENV: py312-install-geth-v1_13_2
   py38-install-geth-v1_13_3:
     <<: *common_go_v1_21_3
     docker:
@@ -467,6 +588,13 @@ jobs:
         environment:
           GETH_VERSION: v1.13.3
           TOXENV: py311-install-geth-v1_13_3
+  py312-install-geth-v1_13_3:
+    <<: *common_go_v1_21_3
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          GETH_VERSION: v1.13.3
+          TOXENV: py312-install-geth-v1_13_3
   py38-install-geth-v1_13_4:
     <<: *common_go_v1_21_3
     docker:
@@ -495,6 +623,13 @@ jobs:
         environment:
           GETH_VERSION: v1.13.4
           TOXENV: py311-install-geth-v1_13_4
+  py312-install-geth-v1_13_4:
+    <<: *common_go_v1_21_3
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          GETH_VERSION: v1.13.4
+          TOXENV: py312-install-geth-v1_13_4
   py38-install-geth-v1_13_5:
     <<: *common_go_v1_21_3
     docker:
@@ -523,6 +658,13 @@ jobs:
         environment:
           GETH_VERSION: v1.13.5
           TOXENV: py311-install-geth-v1_13_5
+  py312-install-geth-v1_13_5:
+    <<: *common_go_v1_21_3
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          GETH_VERSION: v1.13.5
+          TOXENV: py312-install-geth-v1_13_5
   py38-install-geth-v1_13_6:
     <<: *common_go_v1_21_3
     docker:
@@ -551,6 +693,13 @@ jobs:
         environment:
           GETH_VERSION: v1.13.6
           TOXENV: py311-install-geth-v1_13_6
+  py312-install-geth-v1_13_6:
+    <<: *common_go_v1_21_3
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          GETH_VERSION: v1.13.6
+          TOXENV: py312-install-geth-v1_13_6
   py38-install-geth-v1_13_7:
     <<: *common_go_v1_21_3
     docker:
@@ -579,6 +728,13 @@ jobs:
         environment:
           GETH_VERSION: v1.13.7
           TOXENV: py311-install-geth-v1_13_7
+  py312-install-geth-v1_13_7:
+    <<: *common_go_v1_21_3
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          GETH_VERSION: v1.13.7
+          TOXENV: py312-install-geth-v1_13_7
   py38-install-geth-v1_13_8:
     <<: *common_go_v1_21_3
     docker:
@@ -607,6 +763,13 @@ jobs:
         environment:
           GETH_VERSION: v1.13.8
           TOXENV: py311-install-geth-v1_13_8
+  py312-install-geth-v1_13_8:
+    <<: *common_go_v1_21_3
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          GETH_VERSION: v1.13.8
+          TOXENV: py312-install-geth-v1_13_8
   py38-install-geth-v1_13_9:
     <<: *common_go_v1_21_3
     docker:
@@ -635,6 +798,13 @@ jobs:
         environment:
           GETH_VERSION: v1.13.9
           TOXENV: py311-install-geth-v1_13_9
+  py312-install-geth-v1_13_9:
+    <<: *common_go_v1_21_3
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          GETH_VERSION: v1.13.9
+          TOXENV: py312-install-geth-v1_13_9
   py38-install-geth-v1_13_10:
     <<: *common_go_v1_21_3
     docker:
@@ -663,6 +833,13 @@ jobs:
         environment:
           GETH_VERSION: v1.13.10
           TOXENV: py311-install-geth-v1_13_10
+  py312-install-geth-v1_13_10:
+    <<: *common_go_v1_21_3
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          GETH_VERSION: v1.13.10
+          TOXENV: py312-install-geth-v1_13_10
   py38-install-geth-v1_13_11:
     <<: *common_go_v1_21_3
     docker:
@@ -691,6 +868,13 @@ jobs:
         environment:
           GETH_VERSION: v1.13.11
           TOXENV: py311-install-geth-v1_13_11
+  py312-install-geth-v1_13_11:
+    <<: *common_go_v1_21_3
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          GETH_VERSION: v1.13.11
+          TOXENV: py312-install-geth-v1_13_11
 
   py38-lint:
     <<: *common_go_v1_21_3
@@ -716,6 +900,12 @@ jobs:
       - image: cimg/python:3.11
         environment:
           TOXENV: py311-lint
+  py312-lint:
+    <<: *common_go_v1_21_3
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          TOXENV: py312-lint
 
   py38-wheel:
     <<: *common_go_v1_21_3
@@ -741,11 +931,38 @@ jobs:
       - image: cimg/python:3.11
         environment:
           TOXENV: py311-wheel
+  py312-wheel:
+    <<: *common_go_v1_21_3
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          TOXENV: py312-wheel
 
-  py311-wheel-windows:
-    <<: *windows_steps
-    environment:
-      TOXENV: py311-wheel-windows
+  py311-windows-wheel:
+    <<: *windows-wheel-setup
+    steps:
+      - checkout
+      - <<: *restore-cache-step
+      - <<: *install-pyenv-step
+      - run:
+          name: set minor version
+          command: echo "export MINOR_VERSION='3.11'" >> $BASH_ENV
+      - <<: *install-latest-python-step
+      - <<: *run-tox-step
+      - <<: *save-cache-step
+
+  py312-windows-wheel:
+    <<: *windows-wheel-setup
+    steps:
+      - checkout
+      - <<: *restore-cache-step
+      - <<: *install-pyenv-step
+      - run:
+          name: set minor version
+          command: echo "export MINOR_VERSION='3.12'" >> $BASH_ENV
+      - <<: *install-latest-python-step
+      - <<: *run-tox-step
+      - <<: *save-cache-step
 
 workflows:
   version: 2
@@ -755,120 +972,143 @@ workflows:
       - py39-install-geth-v1_11_0
       - py310-install-geth-v1_11_0
       - py311-install-geth-v1_11_0
+      - py312-install-geth-v1_11_0
 
       - py38-install-geth-v1_11_1
       - py39-install-geth-v1_11_1
       - py310-install-geth-v1_11_1
       - py311-install-geth-v1_11_1
+      - py312-install-geth-v1_11_1
 
       - py38-install-geth-v1_11_2
       - py39-install-geth-v1_11_2
       - py310-install-geth-v1_11_2
       - py311-install-geth-v1_11_2
+      - py312-install-geth-v1_11_2
 
       - py38-install-geth-v1_11_3
       - py39-install-geth-v1_11_3
       - py310-install-geth-v1_11_3
       - py311-install-geth-v1_11_3
+      - py312-install-geth-v1_11_3
 
       - py38-install-geth-v1_11_4
       - py39-install-geth-v1_11_4
       - py310-install-geth-v1_11_4
       - py311-install-geth-v1_11_4
+      - py312-install-geth-v1_11_4
 
       - py38-install-geth-v1_11_5
       - py39-install-geth-v1_11_5
       - py310-install-geth-v1_11_5
       - py311-install-geth-v1_11_5
+      - py312-install-geth-v1_11_5
 
       - py38-install-geth-v1_11_6
       - py39-install-geth-v1_11_6
       - py310-install-geth-v1_11_6
       - py311-install-geth-v1_11_6
+      - py312-install-geth-v1_11_6
 
       - py38-install-geth-v1_12_0
       - py39-install-geth-v1_12_0
       - py310-install-geth-v1_12_0
       - py311-install-geth-v1_12_0
+      - py312-install-geth-v1_12_0
 
       - py38-install-geth-v1_12_1
       - py39-install-geth-v1_12_1
       - py310-install-geth-v1_12_1
       - py311-install-geth-v1_12_1
+      - py312-install-geth-v1_12_1
 
       - py38-install-geth-v1_12_2
       - py39-install-geth-v1_12_2
       - py310-install-geth-v1_12_2
       - py311-install-geth-v1_12_2
+      - py312-install-geth-v1_12_2
 
       - py38-install-geth-v1_13_0
       - py39-install-geth-v1_13_0
       - py310-install-geth-v1_13_0
       - py311-install-geth-v1_13_0
+      - py312-install-geth-v1_13_0
 
       - py38-install-geth-v1_13_1
       - py39-install-geth-v1_13_1
       - py310-install-geth-v1_13_1
       - py311-install-geth-v1_13_1
+      - py312-install-geth-v1_13_1
 
       - py38-install-geth-v1_13_2
       - py39-install-geth-v1_13_2
       - py310-install-geth-v1_13_2
       - py311-install-geth-v1_13_2
+      - py312-install-geth-v1_13_2
 
       - py38-install-geth-v1_13_3
       - py39-install-geth-v1_13_3
       - py310-install-geth-v1_13_3
       - py311-install-geth-v1_13_3
+      - py312-install-geth-v1_13_3
 
       - py38-install-geth-v1_13_4
       - py39-install-geth-v1_13_4
       - py310-install-geth-v1_13_4
       - py311-install-geth-v1_13_4
+      - py312-install-geth-v1_13_4
 
       - py38-install-geth-v1_13_5
       - py39-install-geth-v1_13_5
       - py310-install-geth-v1_13_5
       - py311-install-geth-v1_13_5
+      - py312-install-geth-v1_13_5
 
       - py38-install-geth-v1_13_6
       - py39-install-geth-v1_13_6
       - py310-install-geth-v1_13_6
       - py311-install-geth-v1_13_6
+      - py312-install-geth-v1_13_6
 
       - py38-install-geth-v1_13_7
       - py39-install-geth-v1_13_7
       - py310-install-geth-v1_13_7
       - py311-install-geth-v1_13_7
+      - py312-install-geth-v1_13_7
 
       - py38-install-geth-v1_13_8
       - py39-install-geth-v1_13_8
       - py310-install-geth-v1_13_8
       - py311-install-geth-v1_13_8
+      - py312-install-geth-v1_13_8
 
       - py38-install-geth-v1_13_9
       - py39-install-geth-v1_13_9
       - py310-install-geth-v1_13_9
       - py311-install-geth-v1_13_9
+      - py312-install-geth-v1_13_9
 
       - py38-install-geth-v1_13_10
       - py39-install-geth-v1_13_10
       - py310-install-geth-v1_13_10
       - py311-install-geth-v1_13_10
+      - py312-install-geth-v1_13_10
 
       - py38-install-geth-v1_13_11
       - py39-install-geth-v1_13_11
       - py310-install-geth-v1_13_11
       - py311-install-geth-v1_13_11
+      - py312-install-geth-v1_13_11
 
       - py38-lint
       - py39-lint
       - py310-lint
       - py311-lint
-
+      - py312-lint
       - py38-wheel
       - py39-wheel
       - py310-wheel
       - py311-wheel
-
-      - py311-wheel-windows
+      - py312-wheel
+      - py311-windows-wheel
+      - py312-windows-wheel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,15 +22,12 @@ common_go_v1_21_3: &common_go_v1_21_3
         when: on_fail
     - restore_cache:
         keys:
-          - cache-v6-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
-    - restore_cache:
-        keys:
-          - cache-v5-{{ arch }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+          - cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
     - run:
         name: install dependencies
         command: |
+          python -m pip install --upgrade pip
           python -m pip install tox
-          python -m pip install checksumdir
     - run:
         name: install golang-1.21.3
         command: ./.circleci/install_golang.sh 1.21.3
@@ -93,16 +90,6 @@ windows-wheel-steps:
       paths:
         - .tox
       key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
-
-docs: &docs
-  docker:
-    - image: common
-  steps:
-    - run:
-        name: install latexpdf dependencies
-        command: |
-          sudo apt-get update
-          sudo apt-get install latexmk tex-gyre texlive-fonts-extra
 
 jobs:
   py38-install-geth-v1_11_0:
@@ -1105,6 +1092,7 @@ workflows:
       - py310-lint
       - py311-lint
       - py312-lint
+
       - py38-wheel
       - py39-wheel
       - py310-wheel

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,9 @@ chains
 .cache
 .pytest_cache
 
+# pycache
+__pycache__/
+
 # Test output logs
 logs
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,11 @@ repos:
     -   id: check-toml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v3.15.0
+    hooks:
+    -   id: pyupgrade
+        args: [--py38-plus]
 -   repo: https://github.com/psf/black
     rev: 23.9.1
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -50,11 +50,11 @@ notes: check-bump
 	towncrier build --yes --version $(UPCOMING_VERSION)
 	# Before we bump the version, make sure that the towncrier-generated docs will build
 	make docs
-	git commit -m "Compile release notes"
+	git commit -m "Compile release notes for v$(UPCOMING_VERSION)"
 
 release: check-bump clean
 	# require that upstream is configured for ethereum/py-geth
-	git remote -v | grep "upstream\tgit@github.com:ethereum/py-geth.git (push)\|upstream\thttps://github.com/ethereum/py-geth (push)"
+	@git remote -v | grep -E "upstream\tgit@github.com:ethereum/py-geth.git \(push\)|upstream\thttps://(www.)?github.com/ethereum/py-geth \(push\)"
 	# verify that docs build correctly
 	./newsfragments/validate_files.py is-empty
 	make docs

--- a/geth/accounts.py
+++ b/geth/accounts.py
@@ -57,11 +57,11 @@ def create_new_account(data_dir, password, **geth_kwargs):
     If geth process is already running you can create new
     accounts using
     `web3.personal.newAccount()
-    <https://github.com/ethereum/go-ethereum/wiki/JavaScript-Console#personalnewaccount>_`
+    <https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-personal>_`
+
     RPC API.
 
-
-    Example py.test fixture for tests:
+    Example pytest fixture for tests:
 
     .. code-block:: python
 

--- a/geth/chain.py
+++ b/geth/chain.py
@@ -47,10 +47,8 @@ def get_live_data_dir():
 
     else:
         raise ValueError(
-            (
-                f"Unsupported platform: '{sys.platform}'.  Only darwin/linux2/win32 are"
-                " supported.  You must specify the geth datadir manually"
-            )
+            f"Unsupported platform: '{sys.platform}'.  Only darwin/linux2/win32 are"
+            " supported.  You must specify the geth datadir manually"
         )
     return data_dir
 
@@ -129,7 +127,7 @@ def write_genesis_file(
             "daoForSupport": True,
             # Using the Ethash consensus algorithm is deprecated
             # Instead, use the Clique consensus algorithm
-            # https://geth.ethereum.org/docs/interface/private-network
+            # https://geth.ethereum.org/docs/fundamentals/private-network
             "clique": {"period": clique_period, "epoch": clique_epoch},
         }
 

--- a/geth/exceptions.py
+++ b/geth/exceptions.py
@@ -29,8 +29,7 @@ class GethError(Exception):
 
     def __str__(self):
         return textwrap.dedent(
-            (
-                f"""
+            f"""
         {self.message}
         > command: `{" ".join(self.command)}`
         > return code: `{self.return_code}`
@@ -39,5 +38,4 @@ class GethError(Exception):
         > stdout:
         {self.stderr_data}
         """
-            )
         ).strip()

--- a/geth/mixins.py
+++ b/geth/mixins.py
@@ -1,7 +1,3 @@
-from __future__ import (
-    absolute_import,
-)
-
 import datetime
 import logging
 import os
@@ -72,7 +68,7 @@ class JoinableQueue(queue.Queue):
                 _timeout.check()
 
 
-class InterceptedStreamsMixin(object):
+class InterceptedStreamsMixin:
     """
     Mixin class for GethProcess instances that feeds all of the stdout and
     stderr lines into some set of provided callback functions.
@@ -82,7 +78,7 @@ class InterceptedStreamsMixin(object):
     stderr_callbacks = None
 
     def __init__(self, *args, **kwargs):
-        super(InterceptedStreamsMixin, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.stdout_callbacks = []
         self.stdout_queue = JoinableQueue()
 
@@ -120,7 +116,7 @@ class InterceptedStreamsMixin(object):
             time.sleep(0)
 
     def start(self):
-        super(InterceptedStreamsMixin, self).start()
+        super().start()
 
         spawn(self.produce_stdout_queue)
         spawn(self.produce_stderr_queue)
@@ -129,7 +125,7 @@ class InterceptedStreamsMixin(object):
         spawn(self.consume_stderr_queue)
 
     def stop(self):
-        super(InterceptedStreamsMixin, self).stop()
+        super().stop()
 
         try:
             self.stdout_queue.put(StopIteration)
@@ -155,7 +151,7 @@ class LoggingMixin(InterceptedStreamsMixin):
             construct_logger_file_path("geth", "stderr"),
         )
 
-        super(LoggingMixin, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         stdout_logger = _get_file_logger("geth-stdout", stdout_logfile_path)
         stderr_logger = _get_file_logger("geth-stderr", stderr_logfile_path)

--- a/geth/process.py
+++ b/geth/process.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import socket
 import subprocess
 import time
 import warnings
@@ -50,7 +49,7 @@ from geth.wrapper import (
 logger = logging.getLogger(__name__)
 
 
-class BaseGethProcess(object):
+class BaseGethProcess:
     _proc = None
 
     def __init__(
@@ -164,7 +163,7 @@ class BaseGethProcess(object):
         try:
             with get_ipc_socket(self.ipc_path):
                 pass
-        except socket.error:
+        except OSError:
             return False
         else:
             return True
@@ -208,7 +207,7 @@ class MainnetGethProcess(BaseGethProcess):
         if "data_dir" in geth_kwargs:
             raise ValueError("You cannot specify `data_dir` for a MainnetGethProcess")
 
-        super(MainnetGethProcess, self).__init__(geth_kwargs)
+        super().__init__(geth_kwargs)
 
     @property
     def data_dir(self):
@@ -224,7 +223,7 @@ class LiveGethProcess(MainnetGethProcess):
             ),
             stacklevel=2,
         )
-        super(LiveGethProcess, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
 
 class RopstenGethProcess(BaseGethProcess):
@@ -244,7 +243,7 @@ class RopstenGethProcess(BaseGethProcess):
         geth_kwargs["network_id"] = "3"
         geth_kwargs["data_dir"] = get_ropsten_data_dir()
 
-        super(RopstenGethProcess, self).__init__(geth_kwargs)
+        super().__init__(geth_kwargs)
 
     @property
     def data_dir(self):
@@ -308,4 +307,4 @@ class DevGethProcess(BaseGethProcess):
             )
             initialize_chain(genesis_data, **geth_kwargs)
 
-        super(DevGethProcess, self).__init__(geth_kwargs)
+        super().__init__(geth_kwargs)

--- a/geth/utils/networking.py
+++ b/geth/utils/networking.py
@@ -11,7 +11,7 @@ def is_port_open(port):
     sock = socket.socket()
     try:
         sock.bind(("127.0.0.1", port))
-    except socket.error:
+    except OSError:
         return False
     else:
         return True

--- a/newsfragments/186.internal.rst
+++ b/newsfragments/186.internal.rst
@@ -1,0 +1,1 @@
+Merge template updates, noteably add python 3.12 support

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,32 +1,32 @@
 [tool.autoflake]
-remove_all_unused_imports = "True"
+remove_all_unused_imports = true
 exclude = "__init__.py"
 
 [tool.isort]
-combine_as_imports = "True"
+combine_as_imports = true
 extra_standard_library = "pytest"
 force_grid_wrap = 1
-force_sort_within_sections = "True"
+force_sort_within_sections = true
 known_third_party = "hypothesis,pytest"
 known_first_party = "geth"
 multi_line_output = 3
 profile = "black"
 
 [tool.mypy]
-check_untyped_defs = "True"
-disallow_incomplete_defs = "True"
-disallow_untyped_defs = "True"
-disallow_any_generics = "True"
-disallow_untyped_calls = "True"
-disallow_untyped_decorators = "True"
-disallow_subclassing_any = "True"
-ignore_missing_imports = "True"
-strict_optional = "True"
-strict_equality = "True"
-warn_redundant_casts = "True"
-warn_return_any = "True"
-warn_unused_configs = "True"
-warn_unused_ignores = "True"
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_untyped_defs = true
+disallow_any_generics = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_subclassing_any = true
+ignore_missing_imports = true
+strict_optional = true
+strict_equality = true
+warn_redundant_casts = true
+warn_return_any = true
+warn_unused_configs = true
+warn_unused_ignores = true
 
 
 [tool.pydocstyle]
@@ -63,7 +63,7 @@ add-ignore = "D200,D203,D204,D205,D212,D302,D400,D401,D412,D415"
 
 [tool.pytest.ini_options]
 addopts = "-v --showlocals --durations 10"
-xfail_strict = "True"
+xfail_strict = true
 log_format = "%(levelname)8s  %(asctime)s  %(filename)20s  %(message)s"
 log_date_format = "%m-%d %H:%M:%S"
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 from setuptools import (
     find_packages,
     setup,
@@ -66,5 +65,6 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
 )

--- a/tests/core/test_import.py
+++ b/tests/core/test_import.py
@@ -1,2 +1,0 @@
-def test_import():
-    import geth  # noqa: F401

--- a/tests/core/test_import_and_version.py
+++ b/tests/core/test_import_and_version.py
@@ -1,0 +1,4 @@
+def test_import_and_version():
+    import geth
+
+    assert isinstance(geth.__version__, str)

--- a/tox.ini
+++ b/tox.ini
@@ -28,10 +28,10 @@ passenv=
     PATH
 setenv=
     installation: GETH_RUN_INSTALL_TESTS=enabled
-deps =
+deps=
     .[test]
     install-geth: {[common_geth_installation_and_check]deps}
-basepython =
+basepython=
     windows-wheel: python
     py38: python3.8
     py39: python3.9
@@ -41,8 +41,8 @@ basepython =
 allowlist_externals=bash,make,pre-commit
 
 [common_geth_installation_and_check]
-deps = .[dev,test]
-commands =
+deps=.[dev,test]
+commands=
     bash ./.circleci/install_geth.sh
     pytest {posargs:tests/core}
     pytest {posargs:-s tests/installation}

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,14 @@
 [tox]
-envlist =
-    py{38,39,310,311}-lint
-    py{38,39,310,311}-install-geth-{\
+envlist=
+    py{38,39,310,311,312}-lint
+    py{38,39,310,311,312}-install-geth-{\
         v1_11_0, v1_11_1, v1_11_2, v1_11_3, v1_11_4, v1_11_5, v1_11_6, \
         v1_12_0, v1_12_1, v1_12_2, v1_13_0, v1_13_1, v1_13_2, v1_13_3, \
         v1_13_4, v1_13_5, v1_13_6, v1_13_7, v1_13_8, v1_13_9, v1_13_10, \
         v1_13_11 \
     }
-    py{38,39,310,311}-wheel
-    py311-wheel-windows
+    py{38,39,310,311,312}-wheel
+    windows-wheel
 
 [flake8]
 exclude=venv*,.tox,docs,build
@@ -18,26 +18,27 @@ per-file-ignores=__init__.py:F401
 
 [testenv]
 usedevelop=True
-allowlist_externals =
-    bash
-commands =
+commands=
     install-geth: {[common_geth_installation_and_check]commands}
-passenv =
+passenv=
     GETH_VERSION
     GOROOT
     GOPATH
     HOME
     PATH
-setenv =
+setenv=
     installation: GETH_RUN_INSTALL_TESTS=enabled
 deps =
     .[test]
     install-geth: {[common_geth_installation_and_check]deps}
 basepython =
+    windows-wheel: python
     py38: python3.8
     py39: python3.9
     py310: python3.10
     py311: python3.11
+    py312: python3.12
+allowlist_externals=bash,make,pre-commit
 
 [common_geth_installation_and_check]
 deps = .[dev,test]
@@ -46,12 +47,13 @@ commands =
     pytest {posargs:tests/core}
     pytest {posargs:-s tests/installation}
 
-[testenv:py{38,39,310,311}-lint]
+[testenv:py{38,39,310,311,312}-lint]
 deps=pre-commit
 commands=
+    pre-commit install
     pre-commit run --all-files --show-diff-on-failure
 
-[testenv:py{38,39,310,311}-wheel]
+[testenv:py{38,39,310,311,312}-wheel]
 deps=
     wheel
     build[virtualenv]
@@ -66,13 +68,14 @@ commands=
     python -c "import geth"
 skip_install=true
 
-[testenv:py311-wheel-windows]
+[testenv:windows-wheel]
 deps=
     wheel
     build[virtualenv]
 allowlist_externals=
     bash.exe
 commands=
+    python --version
     python -m pip install --upgrade pip
     bash.exe -c "rm -rf build dist"
     python -m build


### PR DESCRIPTION
### What was wrong?

Merge template updates, most notably adding python 3.12 support

### How was it fixed?

### Todo:

- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/py-geth/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/py-geth/assets/5199899/6e71adf7-f48c-4f66-8188-e9d736b15aae)
