### PR TITLE
validate `geth_kwargs` with a `pydantic` model

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,8 +44,10 @@ repos:
         additional_dependencies:
         -   mdformat-gfm
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.5.1
+    rev: v1.10.0
     hooks:
     -   id: mypy
+        additional_dependencies:
+        -   pydantic
         args: [--follow-imports=silent]
-        exclude: 'conftest.py|tests/|geth/accounts.py|geth/process.py|geth/main.py|geth/mixins.py'
+        exclude: 'conftest.py|tests/|geth/process.py|geth/main.py|geth/mixins.py'

--- a/geth/main.py
+++ b/geth/main.py
@@ -2,6 +2,10 @@ import re
 
 import semantic_version
 
+from geth.utils.validation import (
+    validate_geth_kwargs,
+)
+
 from .utils.encoding import (
     force_text,
 )
@@ -17,6 +21,7 @@ def get_geth_version_info_string(**geth_kwargs):
             "`suffix_args` parameter"
         )
     geth_kwargs["suffix_args"] = ["version"]
+    validate_geth_kwargs(geth_kwargs)
     stdoutdata, stderrdata, command, proc = geth_wrapper(**geth_kwargs)
     return stdoutdata
 
@@ -25,6 +30,7 @@ VERSION_REGEX = r"Version: (.*)\n"
 
 
 def get_geth_version(**geth_kwargs):
+    validate_geth_kwargs(geth_kwargs)
     version_info_string = get_geth_version_info_string(**geth_kwargs)
     version_match = re.search(VERSION_REGEX, force_text(version_info_string, "utf8"))
     if not version_match:

--- a/geth/process.py
+++ b/geth/process.py
@@ -48,6 +48,9 @@ from geth.utils.proc import (
 from geth.utils.timeout import (
     Timeout,
 )
+from geth.utils.validation import (
+    validate_geth_kwargs,
+)
 from geth.wrapper import (
     construct_popen_command,
     construct_test_chain_kwargs,
@@ -68,6 +71,7 @@ class BaseGethProcess:
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     ):
+        validate_geth_kwargs(geth_kwargs)
         self.geth_kwargs = geth_kwargs
         self.command = construct_popen_command(**geth_kwargs)
         self.stdin = stdin
@@ -285,6 +289,7 @@ class DevGethProcess(BaseGethProcess):
 
         self.data_dir = get_chain_data_dir(base_dir, chain_name)
         geth_kwargs = construct_test_chain_kwargs(data_dir=self.data_dir, **overrides)
+        validate_geth_kwargs(geth_kwargs)
 
         # ensure that an account is present
         coinbase = ensure_account_exists(**geth_kwargs)

--- a/geth/utils/validation.py
+++ b/geth/utils/validation.py
@@ -1,0 +1,118 @@
+from __future__ import (
+    annotations,
+)
+
+from typing import (
+    Any,
+    Literal,
+)
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+)
+
+
+class GethKwargs(BaseModel):
+    """
+    A model for the geth_kwargs parameter of the Geth class.
+
+    Attributes
+    ----------
+        autodag (bool): generate a DAG (pre-merge only)
+        allowinsecure (bool): Allow insecure accounts.
+        data_dir (str): The directory to store the chain data.
+        etherbase (str): The account to send mining rewards to.
+        extradata (str): Extra data to include in the block.
+        gasprice (int): Minimum gas price for mining.
+        genesis (str): The genesis file to use.
+        geth_executable: (str) The path to the geth executable
+        ipcdisable (bool): Disable the IPC-RPC server.
+        max_peers (str): Maximum number of network peers.
+        metrics (bool): Enable metrics collection.
+        mine (bool): Enable mining.
+        miner_threads (int): Number of CPU threads to use for mining.
+        network_id (str): The network identifier.
+        nodiscover (bool): Disable network discovery.
+        password (str): Path to a file that contains a password.
+        port (str): The port to listen on.
+        pprof (bool): Enable pprof collection.
+        rpc (bool): Enable the HTTP-RPC server.
+        rpcaddr (str): The HTTP-RPC server listening interface.
+        rpc_port (str): The HTTP-RPC server listening port.
+        rpcapi (str): The HTTP-RPC server API.
+        targetgaslimit (int): Target gas limit for mining.
+        unlock (str): Comma separated list of accounts to unlock.
+        verbosity (int): Logging verbosity.
+        vmodule (str): Logging verbosity module.
+        ws_enabled (bool): Enable the WS-RPC server.
+        ws_addr (str): The WS-RPC server listening interface.
+        ws_api (str): The WS-RPC server API.
+        wsport (int): The WS-RPC server listening port.
+
+    """
+
+    allow_insecure_unlock: bool | None = None
+    autodag: bool | None = False
+    cache: int | None = None
+    data_dir: str | None = None
+    dev_mode: bool | None = None
+    etherbase: str | None = None
+    extradata: str | None = None
+    gasprice: int | None = None
+    gcmode: Literal["full", "archive"] | None = None
+    genesis: str | None = None
+    ipc_api: str | None = None  # deprecated
+    ipc_disable: bool | None = None
+    ipc_path: str | None = None
+    max_peers: str | None = None
+    metrics: bool | None = None
+    mine: bool | None = False
+    miner_threads: int | None = None  # deprecated
+    miner_etherbase: int | None = None
+    network_id: str | None = None
+    no_discover: bool | None = None
+    password: str | None = None
+    preload: str | None = None
+    port: str | None = None
+    pprof: bool | None = None
+    rpc_enabled: bool | None = None
+    rpc_addr: str | None = None
+    rpc_port: str | None = None
+    rpc_api: str | None = None
+    rpc_cors_domain: str | None = None
+    shh: bool | None = None
+    targetgaslimit: int | None = None
+    tx_pool_global_slots: int | None = None
+    tx_pool_price_limit: int | None = None
+    unlock: str | None = None
+    verbosity: int | None = None
+    vmodule: str | None = None
+    ws_enabled: bool | None = None
+    ws_addr: str | None = None
+    ws_api: str | None = None
+    ws_origins: str | None = None
+    ws_port: int | None = None
+    model_config = ConfigDict(extra="forbid")
+
+    geth_executable: str | None = None
+    nice: bool | None = True
+    suffix_args: list[str] | None = None
+    suffix_kwargs: dict[str, Any] | None = None
+    stdin: str | None = None
+
+    def set_field_if_none(self, field_name: str, value: Any) -> None:
+        if getattr(self, field_name, None) is None:
+            setattr(self, field_name, value)
+
+
+def validate_geth_kwargs(geth_kwargs: dict[str, Any]) -> bool:
+    """
+    Converts geth_kwargs to GethKwargs and raises a ValueError if the conversion fails.
+    """
+    try:
+        GethKwargs(**geth_kwargs)
+    except TypeError:
+        # TODO more specific error message
+        raise ValueError("Invalid geth_kwargs")
+    return True

--- a/geth/wrapper.py
+++ b/geth/wrapper.py
@@ -26,6 +26,9 @@ from geth.utils.networking import (
     get_open_port,
     is_port_open,
 )
+from geth.utils.validation import (
+    validate_geth_kwargs,
+)
 
 is_nice_available = functools.partial(is_executable_available, "nice")
 
@@ -305,8 +308,8 @@ def construct_popen_command(  # type: ignore
     return builder.command
 
 
-# type ignored TODO rethink GethKwargs in a separate PR
 def geth_wrapper(**geth_kwargs):  # type: ignore[no-untyped-def]
+    validate_geth_kwargs(geth_kwargs)
     stdin = geth_kwargs.pop("stdin", None)
     command = construct_popen_command(**geth_kwargs)  # type: ignore[no-untyped-call]
 
@@ -334,10 +337,13 @@ def geth_wrapper(**geth_kwargs):  # type: ignore[no-untyped-def]
     return stdoutdata, stderrdata, command, proc
 
 
-# type ignored TODO rethink GethKwargs in a separate PR
 def spawn_geth(  # type: ignore[no-untyped-def]
-    geth_kwargs, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    geth_kwargs: dict[str, Any],
+    stdin=subprocess.PIPE,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
 ):
+    validate_geth_kwargs(geth_kwargs)
     command = construct_popen_command(**geth_kwargs)  # type: ignore[no-untyped-call]
 
     proc = subprocess.Popen(

--- a/newsfragments/199.breaking.rst
+++ b/newsfragments/199.breaking.rst
@@ -1,0 +1,1 @@
+Return type of functions in ``accounts.py`` changed from ``bytes`` to ``str``

--- a/newsfragments/199.internal.rst
+++ b/newsfragments/199.internal.rst
@@ -1,0 +1,1 @@
+Use a pydantic model to validate typing of ``geth_kwargs`` when passed as an argument

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,8 @@ setup(
     py_modules=["geth"],
     install_requires=[
         "semantic-version>=2.6.0",
+        "pydantic>=2.6.0",
+        "eval_type_backport>=0.1.0; python_version < '3.10'",
     ],
     python_requires=">=3.8, <4",
     extras_require=extras_require,

--- a/tests/core/accounts/test_account_list_parsing.py
+++ b/tests/core/accounts/test_account_list_parsing.py
@@ -5,8 +5,8 @@ from geth.accounts import (
 raw_accounts = b"""Account #0: {d3cda913deb6f67967b99d67acdfa1712c293601}
 Account #1: {6f137a71a6f197df2cbbf010dcbd3c444ef5c925}\n"""
 accounts = (
-    b"0xd3cda913deb6f67967b99d67acdfa1712c293601",
-    b"0x6f137a71a6f197df2cbbf010dcbd3c444ef5c925",
+    "0xd3cda913deb6f67967b99d67acdfa1712c293601",
+    "0x6f137a71a6f197df2cbbf010dcbd3c444ef5c925",
 )
 
 

--- a/tests/core/accounts/test_geth_accounts.py
+++ b/tests/core/accounts/test_geth_accounts.py
@@ -6,7 +6,7 @@ from geth.accounts import (
 def test_single_account(one_account_data_dir):
     data_dir = one_account_data_dir
     accounts = get_accounts(data_dir=data_dir)
-    assert tuple(set(accounts)) == (b"0xae71658b3ab452f7e4f03bda6f777b860b2e2ff2",)
+    assert tuple(set(accounts)) == ("0xae71658b3ab452f7e4f03bda6f777b860b2e2ff2",)
 
 
 def test_multiple_accounts(three_account_data_dir):
@@ -14,9 +14,9 @@ def test_multiple_accounts(three_account_data_dir):
     accounts = get_accounts(data_dir=data_dir)
     assert sorted(tuple(set(accounts))) == sorted(
         (
-            b"0xae71658b3ab452f7e4f03bda6f777b860b2e2ff2",
-            b"0xe8e085862a8d951dd78ec5ea784b3e22ee1ca9c6",
-            b"0x0da70f43a568e88168436be52ed129f4a9bbdaf5",
+            "0xae71658b3ab452f7e4f03bda6f777b860b2e2ff2",
+            "0xe8e085862a8d951dd78ec5ea784b3e22ee1ca9c6",
+            "0x0da70f43a568e88168436be52ed129f4a9bbdaf5",
         )
     )
 

--- a/tests/core/utility/test_validation.py
+++ b/tests/core/utility/test_validation.py
@@ -1,0 +1,27 @@
+import pytest
+
+from geth.utils.validation import (
+    validate_geth_kwargs,
+)
+
+
+def test_validate_geth_kwargs_good():
+    geth_kwargs = {
+        "data_dir": "/tmp",
+        "network_id": "123",
+        "rpc_port": "1234",
+        "dev_mode": True,
+    }
+
+    assert validate_geth_kwargs(geth_kwargs) is True
+
+
+def test_validate_geth_kwargs_bad():
+    geth_kwargs = {
+        "data_dir": "/tmp",
+        "network_id": 123,
+        "dev_mode": "abc",
+    }
+
+    with pytest.raises(ValueError):
+        validate_geth_kwargs(geth_kwargs)


### PR DESCRIPTION
### What was wrong?

Currently `geth_kwargs` are passed around as a `dict` which does not allow type checking.

I considered using using `TypedDict`, but `pydantic` offers more flexibility in allowing the user to add additional values to be passed through to `geth`.

 - Added pydantic as a dependency and added `geth/utils/validation.py` to house the new `GethKwargs` pydantic model- it's currently just a dump of all the geth commands I could find, will be cleaned up in a future PR.
 - Adding types for `geth/accounts.py`
 - Validate typing of `geth_kwargs` in `accounts.py` and `reset.py`  and some directly connected functions.
 - Changed return type of functions in `geth/accounts.py` from bytes to string. geth `stdout` and `stderr` are received as bytes, but otherwise it makes no sense to keep passing them around as bytes within py-geth, just a source of potential confusion. Updated tests that checked for byte-string versions of returned accounts.

 - Bumped `mypy` to `v1.10.0`.
 - Add  `"eval_type_backport>=0.1.0; python_version < '3.10'"` to install_requires due to pydantic + future annotations issue: https://github.com/pydantic/pydantic/issues/7873


### How was it fixed?

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/py-geth/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/py-geth/assets/5199899/eb0f9174-ffab-49dd-bba7-14550186bda8)
