### PR TITLE
Pydantic for wrapper.py and process.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,8 +44,10 @@ repos:
         additional_dependencies:
         -   mdformat-gfm
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.5.1
+    rev: v1.10.0
     hooks:
     -   id: mypy
+        additional_dependencies:
+        -   pydantic
         args: [--follow-imports=silent]
-        exclude: 'conftest.py|tests/|geth/accounts.py|geth/process.py|geth/main.py|geth/mixins.py'
+        exclude: 'conftest.py|tests/|geth/process.py|geth/main.py|geth/mixins.py'

--- a/geth/accounts.py
+++ b/geth/accounts.py
@@ -33,9 +33,7 @@ def get_accounts(
     geth_kwargs.data_dir = data_dir
     geth_kwargs.suffix_args = ["account", "list"]
 
-    # TODO spawn_geth still takes a dict, change to GethKwargs when typing wrapper.py
-    geth_kwargs_dict = geth_kwargs.model_dump(exclude_none=True)
-    command, proc = spawn_geth(geth_kwargs_dict)  # type: ignore[no-untyped-call]
+    command, proc = spawn_geth(geth_kwargs)
     stdoutdata, stderrdata = proc.communicate()
 
     if proc.returncode:
@@ -131,9 +129,7 @@ def create_new_account(
     elif not isinstance(password, bytes):
         raise ValueError("Password must be either a path to a file or bytes")
 
-    # TODO spawn_geth still takes a dict, change to GethKwargs when typing wrapper.py
-    geth_kwargs_dict = geth_kwargs.model_dump(exclude_none=True)
-    command, proc = spawn_geth(geth_kwargs_dict)  # type: ignore[no-untyped-call]
+    command, proc = spawn_geth(geth_kwargs)
 
     if isinstance(password, str):
         stdoutdata, stderrdata = proc.communicate()

--- a/geth/main.py
+++ b/geth/main.py
@@ -2,11 +2,15 @@ import re
 
 import semantic_version
 
+from geth.models import (
+    GethKwargs,
+)
+from geth.wrapper import (
+    geth_wrapper,
+)
+
 from .utils.encoding import (
     force_text,
-)
-from .wrapper import (
-    geth_wrapper,
 )
 
 
@@ -17,7 +21,9 @@ def get_geth_version_info_string(**geth_kwargs):
             "`suffix_args` parameter"
         )
     geth_kwargs["suffix_args"] = ["version"]
-    stdoutdata, stderrdata, command, proc = geth_wrapper(**geth_kwargs)
+    # TODO convert to GethKwargs in function args in separate PR
+    geth_kwargs_model = GethKwargs(**geth_kwargs)
+    stdoutdata, stderrdata, command, proc = geth_wrapper(geth_kwargs_model)
     return stdoutdata
 
 

--- a/geth/models.py
+++ b/geth/models.py
@@ -62,7 +62,6 @@ class GethKwargs(BaseModel):
     gasprice: int | None = None
     gcmode: Literal["full", "archive"] | None = None
     genesis: str | None = None
-    ipc_api: str | None = None  # deprecated
     ipc_disable: bool | None = None
     ipc_path: str | None = None
     max_peers: str | None = None

--- a/geth/models.py
+++ b/geth/models.py
@@ -1,0 +1,106 @@
+from __future__ import (
+    annotations,
+)
+
+from typing import (
+    Any,
+    Literal,
+)
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+)
+
+
+class GethKwargs(BaseModel):
+    """
+    A model for the geth_kwargs parameter of the Geth class.
+
+    Attributes
+    ----------
+        autodag (bool): generate a DAG (pre-merge only)
+        allowinsecure (bool): Allow insecure accounts.
+        data_dir (str): The directory to store the chain data.
+        etherbase (str): The account to send mining rewards to.
+        extradata (str): Extra data to include in the block.
+        gasprice (int): Minimum gas price for mining.
+        genesis (str): The genesis file to use.
+        geth_executable: (str) The path to the geth executable
+        ipcdisable (bool): Disable the IPC-RPC server.
+        max_peers (str): Maximum number of network peers.
+        metrics (bool): Enable metrics collection.
+        mine (bool): Enable mining.
+        miner_threads (int): Number of CPU threads to use for mining.
+        network_id (str): The network identifier.
+        nodiscover (bool): Disable network discovery.
+        password (str): Path to a file that contains a password.
+        port (str): The port to listen on.
+        pprof (bool): Enable pprof collection.
+        rpc (bool): Enable the HTTP-RPC server.
+        rpcaddr (str): The HTTP-RPC server listening interface.
+        rpc_port (str): The HTTP-RPC server listening port.
+        rpcapi (str): The HTTP-RPC server API.
+        targetgaslimit (int): Target gas limit for mining.
+        unlock (str): Comma separated list of accounts to unlock.
+        verbosity (int): Logging verbosity.
+        vmodule (str): Logging verbosity module.
+        ws_enabled (bool): Enable the WS-RPC server.
+        ws_addr (str): The WS-RPC server listening interface.
+        ws_api (str): The WS-RPC server API.
+        wsport (int): The WS-RPC server listening port.
+
+    """
+
+    allow_insecure_unlock: bool | None = None
+    autodag: bool | None = False
+    cache: int | None = None
+    data_dir: str | None = None
+    dev_mode: bool | None = None
+    etherbase: str | None = None
+    extradata: str | None = None
+    gasprice: int | None = None
+    gcmode: Literal["full", "archive"] | None = None
+    genesis: str | None = None
+    ipc_api: str | None = None  # deprecated
+    ipc_disable: bool | None = None
+    ipc_path: str | None = None
+    max_peers: str | None = None
+    metrics: bool | None = None
+    mine: bool | None = False
+    miner_threads: int | None = None  # deprecated
+    miner_etherbase: int | None = None
+    network_id: str | None = None
+    no_discover: bool | None = None
+    password: str | None = None
+    preload: str | None = None
+    port: str | None = None
+    pprof: bool | None = None
+    rpc_enabled: bool | None = None
+    rpc_addr: str | None = None
+    rpc_port: str | None = None
+    rpc_api: str | None = None
+    rpc_cors_domain: str | None = None
+    shh: bool | None = None
+    targetgaslimit: int | None = None
+    tx_pool_global_slots: int | None = None
+    tx_pool_price_limit: int | None = None
+    unlock: str | None = None
+    verbosity: int | None = None
+    vmodule: str | None = None
+    ws_enabled: bool | None = None
+    ws_addr: str | None = None
+    ws_api: str | None = None
+    ws_origins: str | None = None
+    ws_port: int | None = None
+    model_config = ConfigDict(extra="forbid")
+
+    geth_executable: str | None = None
+    nice: bool | None = True
+    suffix_args: list[str] | None = None
+    suffix_kwargs: dict[str, Any] | None = None
+    stdin: str | None = None
+
+    def set_field_if_none(self, field_name: str, value: Any) -> None:
+        if getattr(self, field_name, None) is None:
+            setattr(self, field_name, value)

--- a/geth/process.py
+++ b/geth/process.py
@@ -72,7 +72,8 @@ class BaseGethProcess:
         stderr=subprocess.PIPE,
     ):
         self.geth_kwargs = geth_kwargs
-        self.command = construct_popen_command(**geth_kwargs)
+        geth_kwargs_model = GethKwargs(**geth_kwargs)
+        self.command = construct_popen_command(geth_kwargs_model)
         self.stdin = stdin
         self.stdout = stdout
         self.stderr = stderr

--- a/geth/process.py
+++ b/geth/process.py
@@ -36,6 +36,9 @@ from geth.chain import (
     is_live_chain,
     is_ropsten_chain,
 )
+from geth.models import (
+    GethKwargs,
+)
 from geth.utils.dag import (
     is_dag_generated,
 )
@@ -115,7 +118,9 @@ class BaseGethProcess:
 
     @property
     def accounts(self):
-        return get_accounts(**self.geth_kwargs)
+        # TODO convert to GethKwargs earlier in the process
+        geth_kwargs_model = GethKwargs(**self.geth_kwargs)
+        return get_accounts(geth_kwargs_model.data_dir, geth_kwargs_model)
 
     @property
     def rpc_enabled(self):
@@ -287,7 +292,10 @@ class DevGethProcess(BaseGethProcess):
         geth_kwargs = construct_test_chain_kwargs(data_dir=self.data_dir, **overrides)
 
         # ensure that an account is present
-        coinbase = ensure_account_exists(**geth_kwargs)
+        # TODO: convert geth_kwargs earlier in the process
+        geth_kwargs_model = GethKwargs(**geth_kwargs)
+
+        coinbase = ensure_account_exists(self.data_dir, geth_kwargs_model)
 
         # ensure that the chain is initialized
         genesis_file_path = get_genesis_file_path(self.data_dir)

--- a/geth/reset.py
+++ b/geth/reset.py
@@ -46,9 +46,7 @@ def soft_reset_chain(
 
     geth_kwargs.suffix_args = suffix_args
 
-    # TODO spawn_geth still takes a dict, change to GethKwargs when typing wrapper.py
-    geth_kwargs_dict = geth_kwargs.model_dump(exclude_none=True)
-    _, proc = spawn_geth(geth_kwargs_dict)  # type: ignore[no-untyped-call]
+    _, proc = spawn_geth(geth_kwargs)
 
     stdoutdata, stderrdata = proc.communicate(b"y")
 

--- a/geth/wrapper.py
+++ b/geth/wrapper.py
@@ -16,6 +16,12 @@ from typing import (
 from geth.exceptions import (
     GethError,
 )
+from geth.models import (
+    GethKwargs,
+)
+from geth.types import (
+    IO_Any,
+)
 from geth.utils.encoding import (
     force_bytes,
 )
@@ -114,50 +120,50 @@ class CommandBuilder:
         self.command.extend([str(v) for v in value_list])
 
 
-# type ignored TODO rethink GethKwargs in a separate PR
-def construct_popen_command(  # type: ignore
-    data_dir=None,
-    dev_mode=None,
-    geth_executable=None,
-    max_peers=None,
-    network_id=None,
-    no_discover=None,
-    mine=False,
-    autodag=False,
-    miner_threads=None,  # deprecated
-    miner_etherbase=None,
-    nice=True,
-    unlock=None,
-    password=None,
-    preload=None,
-    port=None,
-    verbosity=None,
-    ipc_disable=None,
-    ipc_path=None,
-    ipc_disabled=None,
-    rpc_enabled=None,
-    rpc_addr=None,
-    rpc_port=None,
-    rpc_api=None,
-    rpc_cors_domain=None,
-    ws_enabled=None,
-    ws_addr=None,
-    ws_origins=None,
-    ws_port=None,
-    ws_api=None,
-    suffix_args=None,
-    suffix_kwargs=None,
-    shh=None,
-    allow_insecure_unlock=None,
-    tx_pool_global_slots=None,
-    tx_pool_price_limit=None,
-    cache=None,
-    gcmode=None,
-):
-    if geth_executable is None:
-        geth_executable = get_geth_binary_path()
+def construct_popen_command(
+    geth_kwargs: GethKwargs,
+    # data_dir=None,
+    # dev_mode=None,
+    # geth_executable=None,
+    # max_peers=None,
+    # network_id=None,
+    # no_discover=None,
+    # mine=False,
+    # autodag=False,
+    # miner_threads=None,  # deprecated
+    # miner_etherbase=None,
+    # nice=True,
+    # unlock=None,
+    # password=None,
+    # preload=None,
+    # port=None,
+    # verbosity=None,
+    # ipc_disable=None,
+    # ipc_path=None,
+    # ipc_disabled=None,
+    # rpc_enabled=None,
+    # rpc_addr=None,
+    # rpc_port=None,
+    # rpc_api=None,
+    # rpc_cors_domain=None,
+    # ws_enabled=None,
+    # ws_addr=None,
+    # ws_origins=None,
+    # ws_port=None,
+    # ws_api=None,
+    # suffix_args=None,
+    # suffix_kwargs=None,
+    # shh=None,
+    # allow_insecure_unlock=None,
+    # tx_pool_global_slots=None,
+    # tx_pool_price_limit=None,
+    # cache=None,
+    # gcmode=None,
+) -> list[str]:
+    if geth_kwargs.geth_executable is None:
+        geth_kwargs.geth_executable = get_geth_binary_path()
 
-    if not is_executable_available(geth_executable):
+    if not is_executable_available(geth_kwargs.geth_executable):
         raise ValueError(
             "No geth executable found.  Please ensure geth is installed and "
             "available on your PATH or use the GETH_BINARY environment variable"
@@ -165,144 +171,145 @@ def construct_popen_command(  # type: ignore
 
     builder = CommandBuilder()
 
-    if nice and is_nice_available():
+    if geth_kwargs.nice and is_nice_available():
         builder.extend(("nice", "-n", "20"))
 
-    builder.append(geth_executable)
+    builder.append(geth_kwargs.geth_executable)
 
-    if dev_mode:
+    if geth_kwargs.dev_mode:
         builder.append("--dev")
 
-    if rpc_enabled:
+    if geth_kwargs.rpc_enabled:
         builder.append("--http")
 
-    if rpc_addr is not None:
-        builder.extend(("--http.addr", rpc_addr))
+    if geth_kwargs.rpc_addr is not None:
+        builder.extend(("--http.addr", geth_kwargs.rpc_addr))
 
-    if rpc_port is not None:
-        builder.extend(("--http.port", rpc_port))
+    if geth_kwargs.rpc_port is not None:
+        builder.extend(("--http.port", geth_kwargs.rpc_port))
 
-    if rpc_api is not None:
-        builder.extend(("--http.api", rpc_api))
+    if geth_kwargs.rpc_api is not None:
+        builder.extend(("--http.api", geth_kwargs.rpc_api))
 
-    if rpc_cors_domain is not None:
-        builder.extend(("--http.corsdomain", rpc_cors_domain))
+    if geth_kwargs.rpc_cors_domain is not None:
+        builder.extend(("--http.corsdomain", geth_kwargs.rpc_cors_domain))
 
-    if ws_enabled:
+    if geth_kwargs.ws_enabled:
         builder.append("--ws")
 
-    if ws_addr is not None:
-        builder.extend(("--ws.addr", ws_addr))
+    if geth_kwargs.ws_addr is not None:
+        builder.extend(("--ws.addr", geth_kwargs.ws_addr))
 
-    if ws_origins is not None:
-        builder.extend(("--ws.origins", ws_port))
+    if geth_kwargs.ws_origins is not None:
+        builder.extend(("--ws.origins", geth_kwargs.ws_port))
 
-    if ws_port is not None:
-        builder.extend(("--ws.port", ws_port))
+    if geth_kwargs.ws_port is not None:
+        builder.extend(("--ws.port", geth_kwargs.ws_port))
 
-    if ws_api is not None:
-        builder.extend(("--ws.api", ws_api))
+    if geth_kwargs.ws_api is not None:
+        builder.extend(("--ws.api", geth_kwargs.ws_api))
 
-    if data_dir is not None:
-        builder.extend(("--datadir", data_dir))
+    if geth_kwargs.data_dir is not None:
+        builder.extend(("--datadir", geth_kwargs.data_dir))
 
-    if max_peers is not None:
-        builder.extend(("--maxpeers", max_peers))
+    if geth_kwargs.max_peers is not None:
+        builder.extend(("--maxpeers", geth_kwargs.max_peers))
 
-    if network_id is not None:
-        builder.extend(("--networkid", network_id))
+    if geth_kwargs.network_id is not None:
+        builder.extend(("--networkid", geth_kwargs.network_id))
 
-    if port is not None:
-        builder.extend(("--port", port))
+    if geth_kwargs.port is not None:
+        builder.extend(("--port", geth_kwargs.port))
 
-    if ipc_disable:
+    if geth_kwargs.ipc_disable:
         builder.append("--ipcdisable")
 
-    if ipc_path is not None:
-        builder.extend(("--ipcpath", ipc_path))
+    if geth_kwargs.ipc_path is not None:
+        builder.extend(("--ipcpath", geth_kwargs.ipc_path))
 
-    if verbosity is not None:
+    if geth_kwargs.verbosity is not None:
         builder.extend(
             (
                 "--verbosity",
-                verbosity,
+                geth_kwargs.verbosity,
             )
         )
 
-    if unlock is not None:
+    if geth_kwargs.unlock is not None:
         builder.extend(
             (
                 "--unlock",
-                unlock,
+                geth_kwargs.unlock,
             )
         )
 
-    if password is not None:
+    if geth_kwargs.password is not None:
         builder.extend(
             (
                 "--password",
-                password,
+                geth_kwargs.password,
             )
         )
 
-    if preload is not None:
-        builder.extend(("--preload", preload))
+    if geth_kwargs.preload is not None:
+        builder.extend(("--preload", geth_kwargs.preload))
 
-    if no_discover:
+    if geth_kwargs.no_discover:
         builder.append("--nodiscover")
 
-    if mine:
-        if unlock is None:
+    if geth_kwargs.mine:
+        if geth_kwargs.unlock is None:
             raise ValueError("Cannot mine without an unlocked account")
         builder.append("--mine")
 
-    if miner_threads is not None:
+    if geth_kwargs.miner_threads is not None:
         logging.warning(
             "`--miner.threads` is deprecated and will be removed in a future release."
         )
-        if not mine:
+        if not geth_kwargs.mine:
             raise ValueError("`mine` must be truthy when specifying `miner_threads`")
-        builder.extend(("--miner.threads", miner_threads))
+        builder.extend(("--miner.threads", geth_kwargs.miner_threads))
 
-    if miner_etherbase is not None:
-        if not mine:
+    if geth_kwargs.miner_etherbase is not None:
+        if not geth_kwargs.mine:
             raise ValueError("`mine` must be truthy when specifying `miner_etherbase`")
-        builder.extend(("--miner.etherbase", miner_etherbase))
+        builder.extend(("--miner.etherbase", geth_kwargs.miner_etherbase))
 
-    if autodag:
+    if geth_kwargs.autodag:
         builder.append("--autodag")
 
-    if shh:
+    if geth_kwargs.shh:
         builder.append("--shh")
 
-    if allow_insecure_unlock:
+    if geth_kwargs.allow_insecure_unlock:
         builder.append("--allow-insecure-unlock")
 
-    if tx_pool_global_slots is not None:
-        builder.extend(("--txpool.globalslots", tx_pool_global_slots))
+    if geth_kwargs.tx_pool_global_slots is not None:
+        builder.extend(("--txpool.globalslots", geth_kwargs.tx_pool_global_slots))
 
-    if tx_pool_price_limit is not None:
-        builder.extend(("--txpool.pricelimit", tx_pool_price_limit))
+    if geth_kwargs.tx_pool_price_limit is not None:
+        builder.extend(("--txpool.pricelimit", geth_kwargs.tx_pool_price_limit))
 
-    if cache:
-        builder.extend(("--cache", cache))
+    if geth_kwargs.cache:
+        builder.extend(("--cache", geth_kwargs.cache))
 
-    if gcmode:
-        builder.extend(("--gcmode", gcmode))
+    if geth_kwargs.gcmode:
+        builder.extend(("--gcmode", geth_kwargs.gcmode))
 
-    if suffix_kwargs:
-        builder.extend(suffix_kwargs)
+    if geth_kwargs.suffix_kwargs:
+        builder.extend(geth_kwargs.suffix_kwargs)
 
-    if suffix_args:
-        builder.extend(suffix_args)
+    if geth_kwargs.suffix_args:
+        builder.extend(geth_kwargs.suffix_args)
 
     return builder.command
 
 
-# type ignored TODO rethink GethKwargs in a separate PR
-def geth_wrapper(**geth_kwargs):  # type: ignore[no-untyped-def]
-    stdin = geth_kwargs.pop("stdin", None)
-    command = construct_popen_command(**geth_kwargs)  # type: ignore[no-untyped-call]
+def geth_wrapper(
+    geth_kwargs: GethKwargs,
+) -> tuple[bytes, bytes, list[str], subprocess.Popen[bytes]]:
+    stdin: str | bytes | None = geth_kwargs.stdin or None
+    command = construct_popen_command(geth_kwargs)
 
     proc = subprocess.Popen(
         command,
@@ -328,11 +335,13 @@ def geth_wrapper(**geth_kwargs):  # type: ignore[no-untyped-def]
     return stdoutdata, stderrdata, command, proc
 
 
-# type ignored TODO rethink GethKwargs in a separate PR
-def spawn_geth(  # type: ignore[no-untyped-def]
-    geth_kwargs, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-):
-    command = construct_popen_command(**geth_kwargs)  # type: ignore[no-untyped-call]
+def spawn_geth(
+    geth_kwargs: GethKwargs,
+    stdin: IO_Any = subprocess.PIPE,
+    stdout: IO_Any = subprocess.PIPE,
+    stderr: IO_Any = subprocess.PIPE,
+) -> tuple[list[str], subprocess.Popen[bytes]]:
+    command = construct_popen_command(geth_kwargs)
 
     proc = subprocess.Popen(
         command,

--- a/geth/wrapper.py
+++ b/geth/wrapper.py
@@ -134,7 +134,6 @@ def construct_popen_command(  # type: ignore
     verbosity=None,
     ipc_disable=None,
     ipc_path=None,
-    ipc_api=None,  # deprecated.
     ipc_disabled=None,
     rpc_enabled=None,
     rpc_addr=None,
@@ -164,11 +163,6 @@ def construct_popen_command(  # type: ignore
             "available on your PATH or use the GETH_BINARY environment variable"
         )
 
-    if ipc_api is not None:
-        raise DeprecationWarning(
-            "The ipc_api flag has been deprecated.  The ipc API is now on by "
-            "default.  Use `ipc_disable=True` to disable this API"
-        )
     builder = CommandBuilder()
 
     if nice and is_nice_available():

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,8 @@ setup(
     py_modules=["geth"],
     install_requires=[
         "semantic-version>=2.6.0",
+        "pydantic>=2.6.0",
+        "eval_type_backport>=0.1.0; python_version < '3.10'",
     ],
     python_requires=">=3.8, <4",
     extras_require=extras_require,

--- a/tests/core/accounts/test_account_list_parsing.py
+++ b/tests/core/accounts/test_account_list_parsing.py
@@ -5,8 +5,8 @@ from geth.accounts import (
 raw_accounts = b"""Account #0: {d3cda913deb6f67967b99d67acdfa1712c293601}
 Account #1: {6f137a71a6f197df2cbbf010dcbd3c444ef5c925}\n"""
 accounts = (
-    b"0xd3cda913deb6f67967b99d67acdfa1712c293601",
-    b"0x6f137a71a6f197df2cbbf010dcbd3c444ef5c925",
+    "0xd3cda913deb6f67967b99d67acdfa1712c293601",
+    "0x6f137a71a6f197df2cbbf010dcbd3c444ef5c925",
 )
 
 

--- a/tests/core/accounts/test_geth_accounts.py
+++ b/tests/core/accounts/test_geth_accounts.py
@@ -6,7 +6,7 @@ from geth.accounts import (
 def test_single_account(one_account_data_dir):
     data_dir = one_account_data_dir
     accounts = get_accounts(data_dir=data_dir)
-    assert tuple(set(accounts)) == (b"0xae71658b3ab452f7e4f03bda6f777b860b2e2ff2",)
+    assert tuple(set(accounts)) == ("0xae71658b3ab452f7e4f03bda6f777b860b2e2ff2",)
 
 
 def test_multiple_accounts(three_account_data_dir):
@@ -14,9 +14,9 @@ def test_multiple_accounts(three_account_data_dir):
     accounts = get_accounts(data_dir=data_dir)
     assert sorted(tuple(set(accounts))) == sorted(
         (
-            b"0xae71658b3ab452f7e4f03bda6f777b860b2e2ff2",
-            b"0xe8e085862a8d951dd78ec5ea784b3e22ee1ca9c6",
-            b"0x0da70f43a568e88168436be52ed129f4a9bbdaf5",
+            "0xae71658b3ab452f7e4f03bda6f777b860b2e2ff2",
+            "0xe8e085862a8d951dd78ec5ea784b3e22ee1ca9c6",
+            "0x0da70f43a568e88168436be52ed129f4a9bbdaf5",
         )
     )
 


### PR DESCRIPTION
### What was wrong?

Converting geth_kwargs dict -> model in wrapper.py


 - Deleted references to deprecated `ipc_api` geth flag - https://github.com/ethereum/go-ethereum/issues/16786

Related to Issue #
Closes #

### How was it fixed?

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/py-geth/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/py-geth/assets/5199899/1e003e51-c094-4c35-9f88-5f9e914a81de)
