### PR TITLE
removed deprecated `ipc_api` and `miner_threads`

### DIFF
--- a/geth/utils/validation.py
+++ b/geth/utils/validation.py
@@ -62,7 +62,6 @@ class GethKwargs(BaseModel):
     gasprice: int | None = None
     gcmode: Literal["full", "archive"] | None = None
     genesis: str | None = None
-    ipc_api: str | None = None  # deprecated
     ipc_disable: bool | None = None
     ipc_path: str | None = None
     max_peers: str | None = None

--- a/geth/utils/validation.py
+++ b/geth/utils/validation.py
@@ -31,7 +31,6 @@ class GethKwargs(BaseModel):
         max_peers (str): Maximum number of network peers.
         metrics (bool): Enable metrics collection.
         mine (bool): Enable mining.
-        miner_threads (int): Number of CPU threads to use for mining.
         network_id (str): The network identifier.
         nodiscover (bool): Disable network discovery.
         password (str): Path to a file that contains a password.
@@ -67,7 +66,6 @@ class GethKwargs(BaseModel):
     max_peers: str | None = None
     metrics: bool | None = None
     mine: bool | None = False
-    miner_threads: int | None = None  # deprecated
     miner_etherbase: int | None = None
     network_id: str | None = None
     no_discover: bool | None = None

--- a/geth/wrapper.py
+++ b/geth/wrapper.py
@@ -137,7 +137,6 @@ def construct_popen_command(  # type: ignore
     verbosity=None,
     ipc_disable=None,
     ipc_path=None,
-    ipc_api=None,  # deprecated.
     ipc_disabled=None,
     rpc_enabled=None,
     rpc_addr=None,
@@ -167,11 +166,6 @@ def construct_popen_command(  # type: ignore
             "available on your PATH or use the GETH_BINARY environment variable"
         )
 
-    if ipc_api is not None:
-        raise DeprecationWarning(
-            "The ipc_api flag has been deprecated.  The ipc API is now on by "
-            "default.  Use `ipc_disable=True` to disable this API"
-        )
     builder = CommandBuilder()
 
     if nice and is_nice_available():

--- a/geth/wrapper.py
+++ b/geth/wrapper.py
@@ -3,7 +3,6 @@ from __future__ import (
 )
 
 import functools
-import logging
 import os
 import subprocess
 import sys
@@ -127,7 +126,6 @@ def construct_popen_command(  # type: ignore
     no_discover=None,
     mine=False,
     autodag=False,
-    miner_threads=None,  # deprecated
     miner_etherbase=None,
     nice=True,
     unlock=None,
@@ -258,14 +256,6 @@ def construct_popen_command(  # type: ignore
         if unlock is None:
             raise ValueError("Cannot mine without an unlocked account")
         builder.append("--mine")
-
-    if miner_threads is not None:
-        logging.warning(
-            "`--miner.threads` is deprecated and will be removed in a future release."
-        )
-        if not mine:
-            raise ValueError("`mine` must be truthy when specifying `miner_threads`")
-        builder.extend(("--miner.threads", miner_threads))
 
     if miner_etherbase is not None:
         if not mine:

--- a/newsfragments/202.removal.rst
+++ b/newsfragments/202.removal.rst
@@ -1,0 +1,1 @@
+Remove deprecated ``ipc_api`` and ``miner_threads`` geth cli flags


### PR DESCRIPTION
### What was wrong?

`ipc_api` and `miner_threads` have been marked as deprecated for some years. This removes them.

Branched from #199, so that needs to merge first. 

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/py-geth/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/py-geth/assets/5199899/dccba745-157c-4c54-823b-ed9d85aea2e3)
