### PR TITLE
add types to `process.py` and `main.py`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,4 +50,4 @@ repos:
         additional_dependencies:
         -   pydantic
         args: [--follow-imports=silent]
-        exclude: 'conftest.py|tests/|geth/process.py|geth/main.py|geth/mixins.py'
+        exclude: 'conftest.py|tests/|geth/mixins.py'

--- a/geth/main.py
+++ b/geth/main.py
@@ -1,4 +1,7 @@
 import re
+from typing import (
+    Any,
+)
 
 import semantic_version
 
@@ -14,7 +17,7 @@ from .wrapper import (
 )
 
 
-def get_geth_version_info_string(**geth_kwargs):
+def get_geth_version_info_string(**geth_kwargs: Any) -> str:
     if "suffix_args" in geth_kwargs:
         raise TypeError(
             "The `get_geth_version` function cannot be called with the "
@@ -22,14 +25,14 @@ def get_geth_version_info_string(**geth_kwargs):
         )
     geth_kwargs["suffix_args"] = ["version"]
     validate_geth_kwargs(geth_kwargs)
-    stdoutdata, stderrdata, command, proc = geth_wrapper(**geth_kwargs)
-    return stdoutdata
+    stdoutdata, stderrdata, command, proc = geth_wrapper(**geth_kwargs)  # type: ignore[no-untyped-call]  # noqa: E501
+    return stdoutdata.decode("utf-8")  # type: ignore[no-any-return]
 
 
 VERSION_REGEX = r"Version: (.*)\n"
 
 
-def get_geth_version(**geth_kwargs):
+def get_geth_version(**geth_kwargs: Any) -> semantic_version.Version:
     validate_geth_kwargs(geth_kwargs)
     version_info_string = get_geth_version_info_string(**geth_kwargs)
     version_match = re.search(VERSION_REGEX, force_text(version_info_string, "utf8"))

--- a/geth/wrapper.py
+++ b/geth/wrapper.py
@@ -116,7 +116,6 @@ class CommandBuilder:
         self.command.extend([str(v) for v in value_list])
 
 
-# type ignored TODO rethink GethKwargs in a separate PR
 def construct_popen_command(  # type: ignore
     data_dir=None,
     dev_mode=None,

--- a/newsfragments/204.breaking.rst
+++ b/newsfragments/204.breaking.rst
@@ -1,0 +1,1 @@
+Changed return type of ``get_geth_version_info_string`` from ``bytes`` to ``str``


### PR DESCRIPTION
### What was wrong?

More types, now for `process.py` and `main.py`.

Branched off of #203, so merge that one first.

No newsfragment for the added types, just one for changing the return type of `get_geth_version_info_string` from `bytes` to `str`.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/py-geth/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/py-geth/assets/5199899/64f10708-9820-4a11-b87c-e2d56bac41b5)
