### PR TITLE
Type wrapper

### DIFF
--- a/geth/main.py
+++ b/geth/main.py
@@ -25,8 +25,8 @@ def get_geth_version_info_string(**geth_kwargs: Any) -> str:
         )
     geth_kwargs["suffix_args"] = ["version"]
     validate_geth_kwargs(geth_kwargs)
-    stdoutdata, stderrdata, command, proc = geth_wrapper(**geth_kwargs)  # type: ignore[no-untyped-call]  # noqa: E501
-    return stdoutdata.decode("utf-8")  # type: ignore[no-any-return]
+    stdoutdata, stderrdata, command, proc = geth_wrapper(**geth_kwargs)
+    return stdoutdata.decode("utf-8")
 
 
 VERSION_REGEX = r"Version: (.*)\n"

--- a/geth/process.py
+++ b/geth/process.py
@@ -80,7 +80,7 @@ class BaseGethProcess:
     ):
         validate_geth_kwargs(geth_kwargs)
         self.geth_kwargs = geth_kwargs
-        self.command = construct_popen_command(**geth_kwargs)  # type: ignore[no-untyped-call]  # noqa: E501
+        self.command = construct_popen_command(**geth_kwargs)
         self.stdin = stdin
         self.stdout = stdout
         self.stderr = stderr

--- a/geth/utils/validation.py
+++ b/geth/utils/validation.py
@@ -22,28 +22,20 @@ class GethKwargs(BaseModel):
         autodag (bool): generate a DAG (pre-merge only)
         allowinsecure (bool): Allow insecure accounts.
         data_dir (str): The directory to store the chain data.
-        etherbase (str): The account to send mining rewards to.
-        extradata (str): Extra data to include in the block.
-        gasprice (int): Minimum gas price for mining.
-        genesis (str): The genesis file to use.
         geth_executable: (str) The path to the geth executable
         ipcdisable (bool): Disable the IPC-RPC server.
         max_peers (str): Maximum number of network peers.
-        metrics (bool): Enable metrics collection.
         mine (bool): Enable mining.
         network_id (str): The network identifier.
         nodiscover (bool): Disable network discovery.
         password (str): Path to a file that contains a password.
         port (str): The port to listen on.
-        pprof (bool): Enable pprof collection.
         rpc (bool): Enable the HTTP-RPC server.
         rpcaddr (str): The HTTP-RPC server listening interface.
         rpc_port (str): The HTTP-RPC server listening port.
         rpcapi (str): The HTTP-RPC server API.
-        targetgaslimit (int): Target gas limit for mining.
         unlock (str): Comma separated list of accounts to unlock.
         verbosity (int): Logging verbosity.
-        vmodule (str): Logging verbosity module.
         ws_enabled (bool): Enable the WS-RPC server.
         ws_addr (str): The WS-RPC server listening interface.
         ws_api (str): The WS-RPC server API.
@@ -55,48 +47,40 @@ class GethKwargs(BaseModel):
     autodag: bool | None = False
     cache: int | None = None
     data_dir: str | None = None
-    dev_mode: bool | None = None
-    etherbase: str | None = None
-    extradata: str | None = None
-    gasprice: int | None = None
+    dev_mode: bool | None = False
     gcmode: Literal["full", "archive"] | None = None
-    genesis: str | None = None
+    geth_executable: str | None = None
     ipc_disable: bool | None = None
     ipc_path: str | None = None
     max_peers: str | None = None
-    metrics: bool | None = None
     mine: bool | None = False
     miner_etherbase: int | None = None
     network_id: str | None = None
+    nice: bool | None = True
     no_discover: bool | None = None
     password: str | None = None
-    preload: str | None = None
     port: str | None = None
-    pprof: bool | None = None
-    rpc_enabled: bool | None = None
+    preload: str | None = None
     rpc_addr: str | None = None
-    rpc_port: str | None = None
     rpc_api: str | None = None
     rpc_cors_domain: str | None = None
+    rpc_enabled: bool | None = None
+    rpc_port: str | None = None
     shh: bool | None = None
-    targetgaslimit: int | None = None
+    stdin: str | None = None
+    suffix_args: list[str] | None = None
+    suffix_kwargs: dict[str, Any] | None = None
     tx_pool_global_slots: int | None = None
     tx_pool_price_limit: int | None = None
     unlock: str | None = None
     verbosity: int | None = None
-    vmodule: str | None = None
-    ws_enabled: bool | None = None
     ws_addr: str | None = None
     ws_api: str | None = None
+    ws_enabled: bool | None = None
     ws_origins: str | None = None
     ws_port: int | None = None
-    model_config = ConfigDict(extra="forbid")
 
-    geth_executable: str | None = None
-    nice: bool | None = True
-    suffix_args: list[str] | None = None
-    suffix_kwargs: dict[str, Any] | None = None
-    stdin: str | None = None
+    model_config = ConfigDict(extra="forbid")
 
     def set_field_if_none(self, field_name: str, value: Any) -> None:
         if getattr(self, field_name, None) is None:

--- a/newsfragments/205.internal.rst
+++ b/newsfragments/205.internal.rst
@@ -1,0 +1,1 @@
+Change args for ``construct_popen_command`` from indivdual kwargs to geth_kwargs and validate with GethKwargs model

--- a/newsfragments/205.removal.rst
+++ b/newsfragments/205.removal.rst
@@ -1,0 +1,1 @@
+Remove handling of ``--ssh`` geth kwarg


### PR DESCRIPTION
### What was wrong?

Adding types to `wrapper.py`.

Rather than keeping 2 lists of accepted `geth_kwargs` (in the args to `construct_popen_command` and in the `GethKwargs` model), `construct_popen_command` now takes the normal `**geth_kwargs` as its arg, then uses `GethKwargs` to validate and fill the default values.

Branched from #204, merge that first

### How was it fixed?

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/py-geth/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/py-geth/assets/5199899/1c102858-b280-4ae2-a36d-913a4f1dbebe)
