### PR TITLE
refactor GethProcess data_dir property

### DIFF
--- a/newsfragments/208.internal.rst
+++ b/newsfragments/208.internal.rst
@@ -1,0 +1,1 @@
+Refactor ``data_dir`` property of ``BaseGethProcess`` and derived classes to fix typing


### PR DESCRIPTION
### What was wrong?

`BaseGethProcess` referred to `self.data_dir`, but `data_dir` is only defined in subclasses.

### How was it fixed?

Gave `BaseGethProcess` a data_dir `abstractmethod`  and updated it for `DevGethProcess`

Branched off of #207, merge that first

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/py-geth/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/py-geth/assets/5199899/e82bd09b-dd1b-4627-934c-6c2805d71e51)
