### PR TITLE
Convert all errors/exceptions to inherit from `PyGethException`

### DIFF
--- a/geth/accounts.py
+++ b/geth/accounts.py
@@ -8,6 +8,9 @@ from typing import (
     Any,
 )
 
+from geth.exceptions import (
+    PyGethValueError,
+)
 from geth.utils.validation import (
     validate_geth_kwargs,
 )
@@ -38,7 +41,7 @@ def get_accounts(data_dir: str, **geth_kwargs: Any) -> tuple[str, ...] | tuple[(
         if "no keys in store" in stderrdata.decode():
             return tuple()
         else:
-            raise ValueError(
+            raise PyGethValueError(
                 format_error_message(
                     "Error trying to list accounts",
                     command,
@@ -118,9 +121,9 @@ def create_new_account(data_dir: str, password: bytes | str, **geth_kwargs: Any)
         if os.path.exists(password):
             geth_kwargs["password"] = password
         else:
-            raise ValueError(f"Password file not found at path: {password}")
+            raise PyGethValueError(f"Password file not found at path: {password}")
     elif not isinstance(password, bytes):
-        raise ValueError("Password must be either a path to a file or bytes")
+        raise PyGethValueError("Password must be either a path to a file or bytes")
 
     command, proc = spawn_geth(geth_kwargs)
 
@@ -130,7 +133,7 @@ def create_new_account(data_dir: str, password: bytes | str, **geth_kwargs: Any)
         stdoutdata, stderrdata = proc.communicate(b"\n".join((password, password)))
 
     if proc.returncode:
-        raise ValueError(
+        raise PyGethValueError(
             format_error_message(
                 "Error trying to create a new account",
                 command,
@@ -142,7 +145,7 @@ def create_new_account(data_dir: str, password: bytes | str, **geth_kwargs: Any)
 
     match = account_regex.search(stdoutdata)
     if not match:
-        raise ValueError(
+        raise PyGethValueError(
             format_error_message(
                 "Did not find an address in process output",
                 command,

--- a/geth/chain.py
+++ b/geth/chain.py
@@ -11,6 +11,9 @@ from typing_extensions import (
     Unpack,
 )
 
+from geth.exceptions import (
+    PyGethValueError,
+)
 from geth.types import (
     GenesisDataTypedDict,
 )
@@ -63,7 +66,7 @@ def get_live_data_dir() -> str:
         )
 
     else:
-        raise ValueError(
+        raise PyGethValueError(
             f"Unsupported platform: '{sys.platform}'.  Only darwin/linux2/win32 are"
             " supported.  You must specify the geth datadir manually"
         )
@@ -109,7 +112,7 @@ def write_genesis_file(
     **genesis_data: Unpack[GenesisDataTypedDict],
 ) -> None:
     if os.path.exists(genesis_file_path) and not overwrite:
-        raise ValueError(
+        raise PyGethValueError(
             "Genesis file already present. Call with "
             "`overwrite=True` to overwrite this file"
         )
@@ -144,7 +147,7 @@ def initialize_chain(genesis_data: GenesisDataTypedDict, data_dir: str) -> None:
     stdoutdata, stderrdata = init_proc.communicate()
     init_proc.wait()
     if init_proc.returncode:
-        raise ValueError(
+        raise PyGethValueError(
             "Error initializing genesis.json: \n"
             f"    stdout={stdoutdata.decode()}\n"
             f"    stderr={stderrdata.decode()}"

--- a/geth/main.py
+++ b/geth/main.py
@@ -5,6 +5,10 @@ from typing import (
 
 import semantic_version
 
+from geth.exceptions import (
+    PyGethTypeError,
+    PyGethValueError,
+)
 from geth.utils.validation import (
     validate_geth_kwargs,
 )
@@ -19,7 +23,7 @@ from .wrapper import (
 
 def get_geth_version_info_string(**geth_kwargs: Any) -> str:
     if "suffix_args" in geth_kwargs:
-        raise TypeError(
+        raise PyGethTypeError(
             "The `get_geth_version` function cannot be called with the "
             "`suffix_args` parameter"
         )
@@ -37,7 +41,7 @@ def get_geth_version(**geth_kwargs: Any) -> semantic_version.Version:
     version_info_string = get_geth_version_info_string(**geth_kwargs)
     version_match = re.search(VERSION_REGEX, force_text(version_info_string, "utf8"))
     if not version_match:
-        raise ValueError(
+        raise PyGethValueError(
             f"Did not match version string in geth output:\n{version_info_string}"
         )
     version_string = version_match.groups()[0]

--- a/geth/mixins.py
+++ b/geth/mixins.py
@@ -13,6 +13,9 @@ from typing import (
     Callable,
 )
 
+from geth.exceptions import (
+    PyGethAttributeError,
+)
 from geth.utils.filesystem import (
     ensure_path_exists,
 )
@@ -113,7 +116,7 @@ class InterceptedStreamsMixin:
                 self.stdout_queue.put(line)
                 time.sleep(0)
         else:
-            raise AttributeError("No `proc` attribute found")
+            raise PyGethAttributeError("No `proc` attribute found")
 
     def produce_stderr_queue(self) -> None:
         if hasattr(self, "proc"):
@@ -121,7 +124,7 @@ class InterceptedStreamsMixin:
                 self.stderr_queue.put(line)
                 time.sleep(0)
         else:
-            raise AttributeError("No `proc` attribute found")
+            raise PyGethAttributeError("No `proc` attribute found")
 
     def consume_stdout_queue(self) -> None:
         for line in self.stdout_queue:

--- a/geth/reset.py
+++ b/geth/reset.py
@@ -7,6 +7,9 @@ from typing import (
     Any,
 )
 
+from geth.exceptions import (
+    PyGethValueError,
+)
 from geth.utils.validation import (
     validate_geth_kwargs,
 )
@@ -31,12 +34,12 @@ def soft_reset_chain(
     data_dir = geth_kwargs.get("data_dir")
 
     if data_dir is None or (not allow_live and is_live_chain(data_dir)):
-        raise ValueError(
+        raise PyGethValueError(
             "To reset the live chain you must call this function with `allow_live=True`"
         )
 
     if not allow_testnet and is_testnet_chain(data_dir):
-        raise ValueError(
+        raise PyGethValueError(
             "To reset the testnet chain you must call this function with `allow_testnet=True`"  # noqa: E501
         )
 
@@ -49,7 +52,7 @@ def soft_reset_chain(
     stdoutdata, stderrdata = proc.communicate(b"y")
 
     if "Removing chaindata" not in stdoutdata.decode():
-        raise ValueError(
+        raise PyGethValueError(
             "An error occurred while removing the chain:\n\nError:\n"
             f"{stderrdata.decode()}\n\nOutput:\n{stdoutdata.decode()}"
         )
@@ -59,12 +62,12 @@ def hard_reset_chain(
     data_dir: str, allow_live: bool = False, allow_testnet: bool = False
 ) -> None:
     if not allow_live and is_live_chain(data_dir):
-        raise ValueError(
+        raise PyGethValueError(
             "To reset the live chain you must call this function with `allow_live=True`"
         )
 
     if not allow_testnet and is_testnet_chain(data_dir):
-        raise ValueError(
+        raise PyGethValueError(
             "To reset the testnet chain you must call this function with `allow_testnet=True`"  # noqa: E501
         )
 

--- a/geth/utils/dag.py
+++ b/geth/utils/dag.py
@@ -5,6 +5,11 @@ from __future__ import (
 import os
 import sys
 
+from geth.exceptions import (
+    PyGethNotImplementedError,
+    PyGethValueError,
+)
+
 MAGIC_PREFIX = b"\xfe\xca\xdd\xba\xad\xde\xe1\xfe"  # 0xfee1deadbaddcafe
 
 
@@ -14,7 +19,7 @@ def get_dag_file_path(
     base_dir: str | None = None,
 ) -> str:
     if seedhash != "0000000000000000":
-        raise NotImplementedError("Non-zero seedhashes are not supported")
+        raise PyGethNotImplementedError("Non-zero seedhashes are not supported")
 
     if base_dir is None:
         if sys.platform in {"darwin", "linux", "linux2", "linux3"}:
@@ -29,7 +34,7 @@ def get_dag_file_path(
                 )
             )
         else:
-            raise ValueError(f"Unknown platform: {sys.platform}")
+            raise PyGethValueError(f"Unknown platform: {sys.platform}")
 
     dag_filename = f"full-R{revision}-{seedhash}"
 

--- a/geth/utils/encoding.py
+++ b/geth/utils/encoding.py
@@ -7,6 +7,10 @@ from typing import (
     Any,
 )
 
+from geth.exceptions import (
+    PyGethTypeError,
+)
+
 
 def is_string(value: Any) -> bool:
     return isinstance(value, (bytes, bytearray, str))
@@ -22,11 +26,11 @@ def force_bytes(value: bytes | bytearray | str, encoding: str = "iso-8859-1") ->
         if isinstance(encoded, (bytes, bytearray)):
             return encoded
         else:
-            raise TypeError(
+            raise PyGethTypeError(
                 f"Encoding {encoding!r} produced non-binary result: {encoded!r}"
             )
     else:
-        raise TypeError(f"Unsupported type: {type(value)}")
+        raise PyGethTypeError(f"Unsupported type: {type(value)}")
 
 
 def force_text(value: bytes | bytearray | str, encoding: str = "iso-8859-1") -> str:
@@ -35,7 +39,7 @@ def force_text(value: bytes | bytearray | str, encoding: str = "iso-8859-1") -> 
     elif isinstance(value, str):
         return value
     else:
-        raise TypeError(f"Unsupported type: {type(value)}")
+        raise PyGethTypeError(f"Unsupported type: {type(value)}")
 
 
 def force_obj_to_text(obj: Any) -> Any:

--- a/geth/utils/timeout.py
+++ b/geth/utils/timeout.py
@@ -11,6 +11,10 @@ from typing import (
     Literal,
 )
 
+from geth.exceptions import (
+    PyGethValueError,
+)
+
 
 class Timeout(Exception):
     """
@@ -52,24 +56,24 @@ class Timeout(Exception):
     @property
     def expire_at(self) -> float:
         if self.seconds is None:
-            raise ValueError(
+            raise PyGethValueError(
                 "Timeouts with `seconds == None` do not have an expiration time"
             )
         elif self.begun_at is None:
-            raise ValueError("Timeout has not been started")
+            raise PyGethValueError("Timeout has not been started")
         return self.begun_at + self.seconds
 
     def start(self) -> None:
         if self.is_running is not None:
-            raise ValueError("Timeout has already been started")
+            raise PyGethValueError("Timeout has already been started")
         self.begun_at = time.time()
         self.is_running = True
 
     def check(self) -> None:
         if self.is_running is None:
-            raise ValueError("Timeout has not been started")
+            raise PyGethValueError("Timeout has not been started")
         elif self.is_running is False:
-            raise ValueError("Timeout has already been cancelled")
+            raise PyGethValueError("Timeout has already been cancelled")
         elif self.seconds is None:
             return
         elif time.time() > self.expire_at:

--- a/geth/utils/validation.py
+++ b/geth/utils/validation.py
@@ -13,6 +13,9 @@ from pydantic import (
     ValidationError,
 )
 
+from geth.exceptions import (
+    PyGethValueError,
+)
 from geth.types import (
     GenesisDataTypedDict,
 )
@@ -95,9 +98,9 @@ def validate_geth_kwargs(geth_kwargs: dict[str, Any]) -> bool:
     try:
         GethKwargs(**geth_kwargs)
     except ValidationError as e:
-        raise ValueError(f"geth_kwargs validation failed: {e}")
+        raise PyGethValueError(f"geth_kwargs validation failed: {e}")
     except TypeError as e:
-        raise ValueError(f"error while validating geth_kwargs: {e}")
+        raise PyGethValueError(f"error while validating geth_kwargs: {e}")
     return True
 
 
@@ -155,16 +158,18 @@ def validate_genesis_data(genesis_data: GenesisDataTypedDict) -> bool:
         try:
             GenesisDataConfig(**genesis_data_config)
         except ValidationError as e:
-            raise ValueError(f"genesis_data config field validation failed: {e}")
+            raise PyGethValueError(f"genesis_data config field validation failed: {e}")
         except TypeError as e:
-            raise ValueError(f"error while validating genesis_data config field: {e}")
+            raise PyGethValueError(
+                f"error while validating genesis_data config field: {e}"
+            )
     """
     Validates the genesis data
     """
     try:
         GenesisData(**genesis_data)
     except ValidationError as e:
-        raise ValueError(f"genesis_data validation failed: {e}")
+        raise PyGethValueError(f"genesis_data validation failed: {e}")
     except TypeError as e:
-        raise ValueError(f"error while validating genesis_data: {e}")
+        raise PyGethValueError(f"error while validating genesis_data: {e}")
     return True

--- a/geth/wrapper.py
+++ b/geth/wrapper.py
@@ -13,7 +13,8 @@ from typing import (
 )
 
 from geth.exceptions import (
-    GethError,
+    PyGethGethError,
+    PyGethValueError,
 )
 from geth.types import (
     IO_Any,
@@ -128,7 +129,7 @@ def construct_popen_command(**geth_kwargs: Any) -> list[str]:
         gk.geth_executable = get_geth_binary_path()
 
     if not is_executable_available(gk.geth_executable):
-        raise ValueError(
+        raise PyGethValueError(
             "No geth executable found.  Please ensure geth is installed and "
             "available on your PATH or use the GETH_BINARY environment variable"
         )
@@ -208,12 +209,14 @@ def construct_popen_command(**geth_kwargs: Any) -> list[str]:
 
     if gk.mine:
         if gk.unlock is None:
-            raise ValueError("Cannot mine without an unlocked account")
+            raise PyGethValueError("Cannot mine without an unlocked account")
         builder.append("--mine")
 
     if gk.miner_etherbase is not None:
         if not gk.mine:
-            raise ValueError("`mine` must be truthy when specifying `miner_etherbase`")
+            raise PyGethValueError(
+                "`mine` must be truthy when specifying `miner_etherbase`"
+            )
         builder.extend(("--miner.etherbase", gk.miner_etherbase))
 
     if gk.autodag:
@@ -263,7 +266,7 @@ def geth_wrapper(
     stdoutdata, stderrdata = proc.communicate(stdin)
 
     if proc.returncode != 0:
-        raise GethError(
+        raise PyGethGethError(
             command=command,
             return_code=proc.returncode,
             stdin_data=stdin,

--- a/newsfragments/212.feature.rst
+++ b/newsfragments/212.feature.rst
@@ -1,0 +1,1 @@
+Update all raised ``Exceptions`` to inherit from a ``PyGethException``

--- a/tests/core/utility/test_validation.py
+++ b/tests/core/utility/test_validation.py
@@ -9,6 +9,9 @@ from typing import (
 
 import pytest
 
+from geth.exceptions import (
+    PyGethValueError,
+)
 from geth.types import (
     GenesisDataTypedDict,
 )
@@ -45,7 +48,7 @@ def test_validate_geth_kwargs_good(geth_kwargs):
     ],
 )
 def test_validate_geth_kwargs_bad(geth_kwargs):
-    with pytest.raises(ValueError):
+    with pytest.raises(PyGethValueError):
         validate_geth_kwargs(geth_kwargs)
 
 
@@ -84,7 +87,7 @@ def test_validate_genesis_data_good(genesis_data):
     ],
 )
 def test_validate_genesis_data_bad(genesis_data):
-    with pytest.raises(ValueError):
+    with pytest.raises(PyGethValueError):
         validate_genesis_data(genesis_data)
 
 


### PR DESCRIPTION
### What was wrong?

As in [web3](https://github.com/ethereum/web3.py/blob/main/web3/exceptions.py), we should base all exceptions that `py-geth` throws off of a `PyGethException`

### How was it fixed?

Create `py-geth` flavors of all exceptions we currently raise and replace across the library.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/py-geth/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/py-geth/assets/5199899/86572679-df93-468f-b4b1-2e9f8dd318bc)
