### PR TITLE
Type geth kwargs with typed dict

### DIFF
--- a/geth/accounts.py
+++ b/geth/accounts.py
@@ -67,7 +67,7 @@ account_regex = re.compile(b"([a-f0-9]{40})")
 
 
 def create_new_account(**geth_kwargs: Unpack[GethKwargsTypedDict]) -> str:
-    """
+    r"""
     Creates a new Ethereum account on geth.
 
     This is useful for testing when you want to stress
@@ -117,11 +117,18 @@ def create_new_account(**geth_kwargs: Unpack[GethKwargsTypedDict]) -> str:
             account = create_new_account(data_dir, DEFAULT_PASSWORD_PATH)
             return account
 
-    :param geth_kwargs: Command line arguments to pass to geth Required keys are:
-        data_dir: Geth datadir path - where to keep "keystore" folder
-        password: Password to use for the new account, either the password as bytes
-                  or a str path to a file containing the password
+    :param \**geth_kwargs:
+        Command line arguments to pass to geth. See below:
+
+    :Required Keyword Arguments:
+        * *data_dir* (``str``) --
+          Geth datadir path - where to keep "keystore" folder
+        * *password* (``str`` or ``bytes``) --
+          Password to use for the new account, either the password as bytes or a str
+          path to a file containing the password.
+
     :return: Account as 0x prefixed hex string
+    :rtype: str
     """
     if not geth_kwargs.get("data_dir"):
         raise PyGethValueError("data_dir is required to create a new account")

--- a/geth/accounts.py
+++ b/geth/accounts.py
@@ -33,7 +33,7 @@ def get_accounts(
     """
     Returns all geth accounts as tuple of hex encoded strings
 
-    >>> get_accounts()
+    >>> get_accounts(data_dir='some/data/dir')
     ... ('0x...', '0x...')
     """
     validate_geth_kwargs(geth_kwargs)

--- a/geth/chain.py
+++ b/geth/chain.py
@@ -118,7 +118,7 @@ def write_genesis_file(
         )
 
     validate_genesis_data(genesis_data)
-    # use GenesisData to fill defaults
+    # use GenesisData model to fill defaults
     genesis_data_model = GenesisData(**genesis_data)
 
     with open(genesis_file_path, "w") as genesis_file:

--- a/geth/main.py
+++ b/geth/main.py
@@ -1,13 +1,20 @@
-import re
-from typing import (
-    Any,
+from __future__ import (
+    annotations,
 )
 
+import re
+
 import semantic_version
+from typing_extensions import (
+    Unpack,
+)
 
 from geth.exceptions import (
     PyGethTypeError,
     PyGethValueError,
+)
+from geth.types import (
+    GethKwargsTypedDict,
 )
 from geth.utils.validation import (
     validate_geth_kwargs,
@@ -21,7 +28,7 @@ from .wrapper import (
 )
 
 
-def get_geth_version_info_string(**geth_kwargs: Any) -> str:
+def get_geth_version_info_string(**geth_kwargs: Unpack[GethKwargsTypedDict]) -> str:
     if "suffix_args" in geth_kwargs:
         raise PyGethTypeError(
             "The `get_geth_version` function cannot be called with the "
@@ -36,7 +43,9 @@ def get_geth_version_info_string(**geth_kwargs: Any) -> str:
 VERSION_REGEX = r"Version: (.*)\n"
 
 
-def get_geth_version(**geth_kwargs: Any) -> semantic_version.Version:
+def get_geth_version(
+    **geth_kwargs: Unpack[GethKwargsTypedDict],
+) -> semantic_version.Version:
     validate_geth_kwargs(geth_kwargs)
     version_info_string = get_geth_version_info_string(**geth_kwargs)
     version_match = re.search(VERSION_REGEX, force_text(version_info_string, "utf8"))

--- a/geth/process.py
+++ b/geth/process.py
@@ -296,6 +296,8 @@ class DevGethProcess(BaseGethProcess):
     Geth developer mode process for testing purposes.
     """
 
+    _data_dir: str
+
     def __init__(
         self,
         chain_name: str,

--- a/geth/process.py
+++ b/geth/process.py
@@ -318,7 +318,7 @@ class DevGethProcess(BaseGethProcess):
             base_dir = get_default_base_dir()
 
         self._data_dir = get_chain_data_dir(base_dir, chain_name)
-        overrides["data_dir"] = self._data_dir
+        overrides["data_dir"] = self.data_dir
         geth_kwargs = construct_test_chain_kwargs(**overrides)
         validate_geth_kwargs(geth_kwargs)
 

--- a/geth/process.py
+++ b/geth/process.py
@@ -15,7 +15,6 @@ from types import (
     TracebackType,
 )
 from typing import (
-    Any,
     cast,
 )
 from urllib.error import (
@@ -49,6 +48,7 @@ from geth.exceptions import (
     PyGethValueError,
 )
 from geth.types import (
+    GethKwargsTypedDict,
     IO_Any,
 )
 from geth.utils.dag import (
@@ -83,7 +83,7 @@ class BaseGethProcess(ABC):
 
     def __init__(
         self,
-        geth_kwargs: dict[str, Any],
+        geth_kwargs: GethKwargsTypedDict,
         stdin: IO_Any = subprocess.PIPE,
         stdout: IO_Any = subprocess.PIPE,
         stderr: IO_Any = subprocess.PIPE,
@@ -245,7 +245,7 @@ class BaseGethProcess(ABC):
 
 
 class MainnetGethProcess(BaseGethProcess):
-    def __init__(self, geth_kwargs: dict[str, Any] | None = None):
+    def __init__(self, geth_kwargs: GethKwargsTypedDict | None = None):
         if geth_kwargs is None:
             geth_kwargs = {}
 
@@ -262,7 +262,7 @@ class MainnetGethProcess(BaseGethProcess):
 
 
 class RopstenGethProcess(BaseGethProcess):
-    def __init__(self, geth_kwargs: dict[str, Any] | None = None):
+    def __init__(self, geth_kwargs: GethKwargsTypedDict | None = None):
         if geth_kwargs is None:
             geth_kwargs = {}
 
@@ -300,7 +300,7 @@ class DevGethProcess(BaseGethProcess):
         self,
         chain_name: str,
         base_dir: str | None = None,
-        overrides: dict[str, Any] | None = None,
+        overrides: GethKwargsTypedDict | None = None,
         genesis_data: GenesisDataTypedDict | None = None,
     ):
         if overrides is None:
@@ -318,7 +318,8 @@ class DevGethProcess(BaseGethProcess):
             base_dir = get_default_base_dir()
 
         self._data_dir = get_chain_data_dir(base_dir, chain_name)
-        geth_kwargs = construct_test_chain_kwargs(data_dir=self.data_dir, **overrides)
+        overrides["data_dir"] = self._data_dir
+        geth_kwargs = construct_test_chain_kwargs(**overrides)
         validate_geth_kwargs(geth_kwargs)
 
         # ensure that an account is present

--- a/geth/reset.py
+++ b/geth/reset.py
@@ -3,12 +3,16 @@ from __future__ import (
 )
 
 import os
-from typing import (
-    Any,
+
+from typing_extensions import (
+    Unpack,
 )
 
 from geth.exceptions import (
     PyGethValueError,
+)
+from geth.types import (
+    GethKwargsTypedDict,
 )
 from geth.utils.validation import (
     validate_geth_kwargs,
@@ -28,7 +32,9 @@ from .wrapper import (
 
 
 def soft_reset_chain(
-    allow_live: bool = False, allow_testnet: bool = False, **geth_kwargs: Any
+    allow_live: bool = False,
+    allow_testnet: bool = False,
+    **geth_kwargs: Unpack[GethKwargsTypedDict],
 ) -> None:
     validate_geth_kwargs(geth_kwargs)
     data_dir = geth_kwargs.get("data_dir")
@@ -43,7 +49,7 @@ def soft_reset_chain(
             "To reset the testnet chain you must call this function with `allow_testnet=True`"  # noqa: E501
         )
 
-    suffix_args = geth_kwargs.pop("suffix_args", [])
+    suffix_args = geth_kwargs.pop("suffix_args") or []
     suffix_args.extend(("removedb",))
     geth_kwargs.update({"suffix_args": suffix_args})
 

--- a/geth/types.py
+++ b/geth/types.py
@@ -5,11 +5,51 @@ from __future__ import (
 from typing import (
     IO,
     Any,
+    Literal,
     TypedDict,
     Union,
 )
 
 IO_Any = Union[IO[Any], int, None]
+
+
+class GethKwargsTypedDict(TypedDict, total=False):
+    allow_insecure_unlock: bool | None
+    autodag: bool | None
+    cache: int | None
+    data_dir: str | None
+    dev_mode: bool | None
+    gcmode: Literal["full", "archive"] | None
+    geth_executable: str | None
+    ipc_disable: bool | None
+    ipc_path: str | None
+    max_peers: str | None
+    mine: bool | None
+    miner_etherbase: int | None
+    network_id: str | None
+    nice: bool | None
+    no_discover: bool | None
+    password: bytes | str | None
+    port: str | None
+    preload: str | None
+    rpc_addr: str | None
+    rpc_api: str | None
+    rpc_cors_domain: str | None
+    rpc_enabled: bool | None
+    rpc_port: str | None
+    shh: bool | None
+    stdin: str | None
+    suffix_args: list[str] | None
+    suffix_kwargs: dict[str, Any] | None
+    tx_pool_global_slots: int | None
+    tx_pool_price_limit: int | None
+    unlock: str | None
+    verbosity: int | None
+    ws_addr: str | None
+    ws_api: str | None
+    ws_enabled: bool | None
+    ws_origins: str | None
+    ws_port: str | None
 
 
 class GenesisDataTypedDict(TypedDict, total=False):

--- a/geth/types.py
+++ b/geth/types.py
@@ -16,7 +16,7 @@ IO_Any = Union[IO[Any], int, None]
 class GethKwargsTypedDict(TypedDict, total=False):
     allow_insecure_unlock: bool | None
     autodag: bool | None
-    cache: int | None
+    cache: str | None
     data_dir: str | None
     dev_mode: bool | None
     gcmode: Literal["full", "archive"] | None
@@ -25,7 +25,7 @@ class GethKwargsTypedDict(TypedDict, total=False):
     ipc_path: str | None
     max_peers: str | None
     mine: bool | None
-    miner_etherbase: int | None
+    miner_etherbase: str | None
     network_id: str | None
     nice: bool | None
     no_discover: bool | None
@@ -40,11 +40,11 @@ class GethKwargsTypedDict(TypedDict, total=False):
     shh: bool | None
     stdin: str | None
     suffix_args: list[str] | None
-    suffix_kwargs: dict[str, Any] | None
-    tx_pool_global_slots: int | None
-    tx_pool_price_limit: int | None
+    suffix_kwargs: dict[str, str] | None
+    tx_pool_global_slots: str | None
+    tx_pool_price_limit: str | None
     unlock: str | None
-    verbosity: int | None
+    verbosity: str | None
     ws_addr: str | None
     ws_api: str | None
     ws_enabled: bool | None

--- a/geth/utils/validation.py
+++ b/geth/utils/validation.py
@@ -25,7 +25,7 @@ from geth.types import (
 class GethKwargs(BaseModel):
     allow_insecure_unlock: bool | None = None
     autodag: bool | None = False
-    cache: int | None = None
+    cache: str | None = None
     data_dir: str | None = None
     dev_mode: bool | None = False
     gcmode: Literal["full", "archive"] | None = None
@@ -34,7 +34,7 @@ class GethKwargs(BaseModel):
     ipc_path: str | None = None
     max_peers: str | None = None
     mine: bool | None = False
-    miner_etherbase: int | None = None
+    miner_etherbase: str | None = None
     network_id: str | None = None
     nice: bool | None = True
     no_discover: bool | None = None
@@ -49,11 +49,11 @@ class GethKwargs(BaseModel):
     shh: bool | None = None
     stdin: str | None = None
     suffix_args: list[str] | None = None
-    suffix_kwargs: dict[str, Any] | None = None
-    tx_pool_global_slots: int | None = None
-    tx_pool_price_limit: int | None = None
+    suffix_kwargs: dict[str, str] | None = None
+    tx_pool_global_slots: str | None = None
+    tx_pool_price_limit: str | None = None
     unlock: str | None = None
-    verbosity: int | None = None
+    verbosity: str | None = None
     ws_addr: str | None = None
     ws_api: str | None = None
     ws_enabled: bool | None = None

--- a/geth/utils/validation.py
+++ b/geth/utils/validation.py
@@ -18,39 +18,11 @@ from geth.exceptions import (
 )
 from geth.types import (
     GenesisDataTypedDict,
+    GethKwargsTypedDict,
 )
 
 
 class GethKwargs(BaseModel):
-    """
-    A model for the geth_kwargs parameter of the Geth class.
-
-    Attributes
-    ----------
-        autodag (bool): generate a DAG (pre-merge only)
-        allowinsecure (bool): Allow insecure accounts.
-        data_dir (str): The directory to store the chain data.
-        geth_executable: (str) The path to the geth executable
-        ipcdisable (bool): Disable the IPC-RPC server.
-        max_peers (str): Maximum number of network peers.
-        mine (bool): Enable mining.
-        network_id (str): The network identifier.
-        nodiscover (bool): Disable network discovery.
-        password (str): Path to a file that contains a password.
-        port (str): The port to listen on.
-        rpc (bool): Enable the HTTP-RPC server.
-        rpcaddr (str): The HTTP-RPC server listening interface.
-        rpc_port (str): The HTTP-RPC server listening port.
-        rpcapi (str): The HTTP-RPC server API.
-        unlock (str): Comma separated list of accounts to unlock.
-        verbosity (int): Logging verbosity.
-        ws_enabled (bool): Enable the WS-RPC server.
-        ws_addr (str): The WS-RPC server listening interface.
-        ws_api (str): The WS-RPC server API.
-        wsport (int): The WS-RPC server listening port.
-
-    """
-
     allow_insecure_unlock: bool | None = None
     autodag: bool | None = False
     cache: int | None = None
@@ -66,7 +38,7 @@ class GethKwargs(BaseModel):
     network_id: str | None = None
     nice: bool | None = True
     no_discover: bool | None = None
-    password: str | None = None
+    password: bytes | str | None = None
     port: str | None = None
     preload: str | None = None
     rpc_addr: str | None = None
@@ -86,12 +58,12 @@ class GethKwargs(BaseModel):
     ws_api: str | None = None
     ws_enabled: bool | None = None
     ws_origins: str | None = None
-    ws_port: int | None = None
+    ws_port: str | None = None
 
     model_config = ConfigDict(extra="forbid")
 
 
-def validate_geth_kwargs(geth_kwargs: dict[str, Any]) -> bool:
+def validate_geth_kwargs(geth_kwargs: GethKwargsTypedDict) -> bool:
     """
     Converts geth_kwargs to GethKwargs and raises a ValueError if the conversion fails.
     """

--- a/geth/wrapper.py
+++ b/geth/wrapper.py
@@ -109,7 +109,7 @@ def construct_test_chain_kwargs(
             os.path.join(tempfile.mkdtemp(), "geth.ipc"),
         )
 
-    overrides.setdefault("verbosity", 5)
+    overrides.setdefault("verbosity", "5")
 
     return overrides
 

--- a/newsfragments/213.breaking.rst
+++ b/newsfragments/213.breaking.rst
@@ -1,0 +1,1 @@
+Use ``GethKwargsTypedDict`` to typecheck the ``geth_kwargs`` dict when passed as an argument. Breaks signatures of functions ``get_accounts``, ``create_new_account``, and ``ensure_account_exists``, requiring all ``kwargs`` now.

--- a/tests/core/accounts/test_create_geth_account.py
+++ b/tests/core/accounts/test_create_geth_account.py
@@ -9,12 +9,12 @@ from geth.accounts import (
 def test_create_new_account_with_text_password(tmpdir):
     data_dir = str(tmpdir.mkdir("data-dir"))
 
-    assert not get_accounts(data_dir)
+    assert not get_accounts(data_dir=data_dir)
 
-    account_0 = create_new_account(data_dir, b"some-text-password")
-    account_1 = create_new_account(data_dir, b"some-text-password")
+    account_0 = create_new_account(data_dir=data_dir, password=b"some-text-password")
+    account_1 = create_new_account(data_dir=data_dir, password=b"some-text-password")
 
-    accounts = get_accounts(data_dir)
+    accounts = get_accounts(data_dir=data_dir)
     assert sorted((account_0, account_1)) == sorted(tuple(set(accounts)))
 
 
@@ -26,10 +26,10 @@ def test_create_new_account_with_file_based_password(tmpdir):
 
     data_dir = os.path.dirname(pw_file_path)
 
-    assert not get_accounts(data_dir)
+    assert not get_accounts(data_dir=data_dir)
 
-    account_0 = create_new_account(data_dir, pw_file_path)
-    account_1 = create_new_account(data_dir, pw_file_path)
+    account_0 = create_new_account(data_dir=data_dir, password=pw_file_path)
+    account_1 = create_new_account(data_dir=data_dir, password=pw_file_path)
 
-    accounts = get_accounts(data_dir)
+    accounts = get_accounts(data_dir=data_dir)
     assert sorted((account_0, account_1)) == sorted(tuple(set(accounts)))


### PR DESCRIPTION
### What was wrong?

As done with `GenesisData` in #210, type `geth_kwargs` using a `TypedDict`.


This does break some function signatures in the `accounts.py` file:
 - `get_accounts`
 - `create_new_account`
 - `ensure_account_exits`

They now only take `**geth_kwargs` as their argument, so any positional args must now be passed as kwargs.


Upon reviewing python `subprocess` docs, we should only be passing strings, no ints. Updated `geth_kwargs` fields that were `int` type to all be `str` type.


### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/py-geth/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/py-geth/assets/5199899/641c88b7-8f4f-4b25-9626-6cc88f97834a)
