### PR TITLE
Properly fill `genesis_data` defaults

### DIFF
--- a/geth/chain.py
+++ b/geth/chain.py
@@ -26,7 +26,7 @@ from .utils.filesystem import (
     is_same_path,
 )
 from .utils.validation import (
-    GenesisData,
+    fill_default_genesis_data,
     validate_genesis_data,
 )
 from .wrapper import (
@@ -119,11 +119,11 @@ def write_genesis_file(
 
     validate_genesis_data(genesis_data)
     # use GenesisData model to fill defaults
-    genesis_data_model = GenesisData(**genesis_data)
+    filled_genesis_data_model = fill_default_genesis_data(genesis_data)
 
     with open(genesis_file_path, "w") as genesis_file:
         genesis_file.write(
-            json.dumps(force_obj_to_text(genesis_data_model.model_dump()))
+            json.dumps(force_obj_to_text(filled_genesis_data_model.model_dump()))
         )
 
 

--- a/newsfragments/215.internal.rst
+++ b/newsfragments/215.internal.rst
@@ -1,0 +1,1 @@
+Add ``fill_default_genesis_data`` function to properly fill ``genesis_data`` defaults

--- a/tests/core/utility/test_validation.py
+++ b/tests/core/utility/test_validation.py
@@ -17,6 +17,7 @@ from geth.types import (
 )
 from geth.utils.validation import (
     GenesisData,
+    fill_default_genesis_data,
     validate_genesis_data,
     validate_geth_kwargs,
 )
@@ -34,7 +35,7 @@ from geth.utils.validation import (
     ],
 )
 def test_validate_geth_kwargs_good(geth_kwargs):
-    assert validate_geth_kwargs(geth_kwargs) is True
+    assert validate_geth_kwargs(geth_kwargs) is None
 
 
 @pytest.mark.parametrize(
@@ -63,7 +64,7 @@ def test_validate_geth_kwargs_bad(geth_kwargs):
     ],
 )
 def test_validate_genesis_data_good(genesis_data):
-    assert validate_genesis_data(genesis_data) is True
+    assert validate_genesis_data(genesis_data) is None
 
 
 @pytest.mark.parametrize(
@@ -84,11 +85,156 @@ def test_validate_genesis_data_good(genesis_data):
             "nonce": "abc",
             "config": None,
         },
+        "kangaroo",
     ],
 )
 def test_validate_genesis_data_bad(genesis_data):
     with pytest.raises(PyGethValueError):
         validate_genesis_data(genesis_data)
+
+
+@pytest.mark.parametrize(
+    "genesis_data,expected",
+    [
+        (
+            {
+                "difficulty": "0x00012131",
+                "nonce": "abc",
+                "timestamp": "1234",
+            },
+            {
+                "alloc": {},
+                "coinbase": "0x3333333333333333333333333333333333333333",
+                "config": {
+                    "ethash": {},
+                    "homesteadBlock": 0,
+                    "daoForkBlock": 0,
+                    "daoForkSupport": True,
+                    "eip150Block": 0,
+                    "eip155Block": 0,
+                    "eip158Block": 0,
+                    "byzantiumBlock": 0,
+                    "constantinopleBlock": 0,
+                    "petersburgBlock": 0,
+                    "istanbulBlock": 0,
+                    "berlinBlock": 0,
+                    "londonBlock": 0,
+                    "arrowGlacierBlock": 0,
+                    "grayGlacierBlock": 0,
+                    "terminalTotalDifficulty": 0,
+                    "terminalTotalDifficultyPassed": True,
+                    "shanghaiTime": 0,
+                    "cancunTime": 0,
+                },
+                "difficulty": "0x00012131",
+                "extraData": "0x0000000000000000000000000000000000000000000000000000000000000000",  # noqa: E501
+                "gasLimit": "0x47e7c4",
+                "mixhash": "0x0000000000000000000000000000000000000000000000000000000000000000",  # noqa: E501
+                "nonce": "abc",
+                "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",  # noqa: E501
+                "timestamp": "1234",
+            },
+        ),
+        (
+            {
+                "difficulty": "0x00012131",
+                "nonce": "abc",
+                "config": {
+                    "homesteadBlock": 5,
+                    "daoForkBlock": 1,
+                    "daoForkSupport": False,
+                    "eip150Block": 27777777,
+                    "eip155Block": 99,
+                    "eip158Block": 32,
+                },
+            },
+            {
+                "alloc": {},
+                "coinbase": "0x3333333333333333333333333333333333333333",
+                "config": {
+                    "ethash": {},
+                    "homesteadBlock": 5,
+                    "daoForkBlock": 1,
+                    "daoForkSupport": False,
+                    "eip150Block": 27777777,
+                    "eip155Block": 99,
+                    "eip158Block": 32,
+                    "byzantiumBlock": 0,
+                    "constantinopleBlock": 0,
+                    "petersburgBlock": 0,
+                    "istanbulBlock": 0,
+                    "berlinBlock": 0,
+                    "londonBlock": 0,
+                    "arrowGlacierBlock": 0,
+                    "grayGlacierBlock": 0,
+                    "terminalTotalDifficulty": 0,
+                    "terminalTotalDifficultyPassed": True,
+                    "shanghaiTime": 0,
+                    "cancunTime": 0,
+                },
+                "difficulty": "0x00012131",
+                "extraData": "0x0000000000000000000000000000000000000000000000000000000000000000",  # noqa: E501
+                "gasLimit": "0x47e7c4",
+                "mixhash": "0x0000000000000000000000000000000000000000000000000000000000000000",  # noqa: E501
+                "nonce": "abc",
+                "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",  # noqa: E501
+                "timestamp": "0x0",
+            },
+        ),
+    ],
+)
+def test_fill_default_genesis_data_good(genesis_data, expected):
+    genesis_data_td = GenesisDataTypedDict(**genesis_data)
+    filled_genesis_data = fill_default_genesis_data(genesis_data_td).model_dump()
+    assert filled_genesis_data == expected
+
+
+@pytest.mark.parametrize(
+    "genesis_data,expected_exception,expected_message",
+    [
+        (
+            {
+                "difficulty": "0x00012131",
+                "nonce": "abc",
+                "timestamp": 1234,
+            },
+            PyGethValueError,
+            "genesis_data validation failed while filling defaults: ",
+        ),
+        (
+            {
+                "difficulty": "0x00012131",
+                "nonce": "abc",
+                "config": {
+                    "homesteadBlock": 5,
+                    "daoForkBlock": "beep",
+                    "daoForkSupport": False,
+                    "eip150Block": 27777777,
+                    "eip155Block": 99,
+                    "eip158Block": 32,
+                },
+            },
+            PyGethValueError,
+            "genesis_data validation failed while filling config defaults: ",
+        ),
+        (
+            "abc123",
+            PyGethValueError,
+            "error while filling default genesis_data: ",
+        ),
+        (
+            {"difficulty": "0x00012131", "nonce": "abc", "config": ["beep"]},
+            PyGethValueError,
+            "genesis_data validation failed while filling defaults: ",
+        ),
+    ],
+)
+def test_fill_default_genesis_data_bad(
+    genesis_data, expected_exception, expected_message
+):
+    with pytest.raises(expected_exception) as excinfo:
+        fill_default_genesis_data(genesis_data)
+    assert str(excinfo.value).startswith(expected_message)
 
 
 @pytest.mark.skipif(sys.version_info < (3, 9), reason="get_type_hints requires >=py39")


### PR DESCRIPTION
### What was wrong?

Filling `geth_kwargs` defaults by just creating a model from the dict works fine because its only member that is a dict (`suffix_kwargs`) defaults to `None`. `genesis_data["config"]` does have default values, so just creating a `GenesisData` model from the dict does not fill the sub-dict properly.

### How was it fixed?

Added a `fill_default_genesis_data` function and test.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/py-geth/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/py-geth/assets/5199899/26dc4298-04e4-47b6-8b54-ef348ea96cfc)
