### PR TITLE
Use `__all__` in `__init__.py`

### DIFF
--- a/geth/__init__.py
+++ b/geth/__init__.py
@@ -20,3 +20,14 @@ from .process import (
 )
 
 __version__ = __version("py-geth")
+
+__all__ = (
+    "install_geth",
+    "get_geth_version",
+    "InterceptedStreamsMixin",
+    "LoggingMixin",
+    "MainnetGethProcess",
+    "SepoliaGethProcess",
+    "TestnetGethProcess",
+    "DevGethProcess",
+)

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ envlist=
 exclude=venv*,.tox,docs,build
 extend-ignore=E203
 max-line-length=88
-per-file-ignores=__init__.py:F401
 
 [testenv]
 usedevelop=True


### PR DESCRIPTION
### What was wrong?
F401 error raised

### How was it fixed?
remove `per-file-ignores` from tox and add `__all__` to `__init__.py`

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/py-geth/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/288639eb-4142-46fd-9c5b-ee871694c531)
