### PR TITLE
fix: handle when given None IPC path

### DIFF
--- a/geth/process.py
+++ b/geth/process.py
@@ -186,18 +186,14 @@ class BaseGethProcess(ABC):
 
     @property
     def ipc_path(self) -> str:
-        _ipc_path = self.geth_kwargs.get(
-            "ipc_path",
-            os.path.abspath(
+        return self.geth_kwargs.get("ipc_path") or os.path.abspath(
                 os.path.expanduser(
                     os.path.join(
                         self.data_dir,
                         "geth.ipc",
                     )
                 )
-            ),
-        )
-        return cast(str, _ipc_path)
+            )
 
     @property
     def is_ipc_ready(self) -> bool:

--- a/geth/process.py
+++ b/geth/process.py
@@ -187,13 +187,13 @@ class BaseGethProcess(ABC):
     @property
     def ipc_path(self) -> str:
         return self.geth_kwargs.get("ipc_path") or os.path.abspath(
-                os.path.expanduser(
-                    os.path.join(
-                        self.data_dir,
-                        "geth.ipc",
-                    )
+            os.path.expanduser(
+                os.path.join(
+                    self.data_dir,
+                    "geth.ipc",
                 )
             )
+        )
 
     @property
     def is_ipc_ready(self) -> bool:

--- a/newsfragments/239.bugfix.rst
+++ b/newsfragments/239.bugfix.rst
@@ -1,0 +1,1 @@
+``ipc_path`` property should always return a string

--- a/tests/core/running/test_running_mainnet_chain.py
+++ b/tests/core/running/test_running_mainnet_chain.py
@@ -1,3 +1,5 @@
+import pytest
+
 from geth import (
     MainnetGethProcess,
 )
@@ -26,3 +28,16 @@ def test_live_chain_with_no_overrides():
     geth.stop()
 
     assert geth.is_stopped
+
+
+@pytest.mark.parametrize(
+    "ipc_path",
+    [
+        "",
+        None,
+    ],
+)
+def test_ipc_path_always_returns_a_string(ipc_path):
+    geth = LoggedMainnetGethProcess(geth_kwargs={"ipc_path": ipc_path})
+
+    assert isinstance(geth.ipc_path, str)


### PR DESCRIPTION
### What was wrong?

When given `None` for IPC path, the value of the `ipc_path(self)` property is **not** it's documented type of `str`; it is rather `str | None`.

### How was it fixed?

Move the default value of `ipc_path` outside the `get()` and into an `or <default>`... This way, if given `None` or `""`, it will still use the default value, which I think makes sense, given the documented type of `str`.

The alternative is to change `ipc_path` to be `str | None` which isn't as nice but also ok.

Opening as draft for discussion.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/py-geth/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/2b53b3a6-8b02-4457-a2d9-ad2c7a375441)
