### PR TITLE
add rtd config so rtd will build once docs are added

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,20 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: true
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
+
+# Build all formats for RTD Downloads - htmlzip, pdf, epub
+formats: all


### PR DESCRIPTION
### What was wrong?

Docs will be moving from the README to ReadTheDocs. Having this file already merged will allow the RTD builds to be checked when updating the docs.

### Todo:

- [x] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/py-geth/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/179ba46d-9dc3-4139-9e3c-45bd8b622828)
